### PR TITLE
fix: bind hash credentials to challenge memo

### DIFF
--- a/lib/mpp/methods/tempo/attribution.rb
+++ b/lib/mpp/methods/tempo/attribution.rb
@@ -80,6 +80,19 @@ module Mpp
           memo_server == fingerprint(server_id)
         end
 
+        # Verify challenge-bound nonce in memo.
+        def verify_challenge_binding(memo, challenge_id)
+          return false unless challenge_id
+          return false unless mpp_memo?(memo)
+
+          begin
+            memo_nonce = [memo[52, 14]].pack("H*")
+          rescue ArgumentError
+            return false
+          end
+          memo_nonce == keccak256(challenge_id.encode(Encoding::UTF_8))[0, 7]
+        end
+
         # Decoded memo structure.
         DecodedMemo = Data.define(:version, :server_fingerprint, :client_fingerprint, :nonce)
 

--- a/lib/mpp/methods/tempo/intents.rb
+++ b/lib/mpp/methods/tempo/intents.rb
@@ -51,12 +51,12 @@ module Mpp
           case payload_data["type"]
           when "hash"
             payload = Schemas::HashCredentialPayload.new(type: "hash", hash: payload_data["hash"])
-            verify_hash(payload, req)
+            verify_hash(payload, req, credential: credential)
           when "transaction"
             payload = Schemas::TransactionCredentialPayload.new(
               type: "transaction", signature: payload_data["signature"]
             )
-            verify_transaction(payload, req)
+            verify_transaction(payload, req, credential: credential)
           when "proof"
             payload = Schemas::ProofCredentialPayload.new(
               type: "proof", signature: payload_data["signature"]
@@ -75,7 +75,7 @@ module Mpp
           @rpc_url
         end
 
-        def verify_hash(payload, request)
+        def verify_hash(payload, request, credential:)
           if @store
             store_key = "mpp:charge:#{payload.hash.downcase}"
             raise Mpp::VerificationError, "Transaction hash already used" unless @store.put_if_absent(store_key,
@@ -87,17 +87,17 @@ module Mpp
 
           raise Mpp::VerificationError, "Transaction not found" unless result
           raise Mpp::VerificationError, "Transaction reverted" unless result["status"] == "0x1"
-          unless verify_transfer_logs(
-            result, request
-          )
+          matched_logs = match_transfer_logs(result, request, expected_sender: result["from"])
+          unless matched_logs.any?
             raise Mpp::VerificationError,
               "Transaction must contain a Transfer log matching request parameters"
           end
+          assert_challenge_bound_memo(matched_logs, credential.challenge) unless request.method_details.memo
 
           Mpp::Receipt.success(payload.hash)
         end
 
-        def verify_transaction(payload, request)
+        def verify_transaction(payload, request, credential:)
           validate_transaction_payload(payload.signature, request)
 
           raw_tx = payload.signature
@@ -128,18 +128,23 @@ module Mpp
 
           raise Mpp::VerificationError, "Transaction receipt not found after retries" unless receipt_data
           raise Mpp::VerificationError, "Transaction reverted" unless receipt_data["status"] == "0x1"
-          unless verify_transfer_logs(
-            receipt_data, request
-          )
+          matched_logs = match_transfer_logs(receipt_data, request, expected_sender: receipt_data["from"])
+          unless matched_logs.any?
             raise Mpp::VerificationError,
               "Transaction must contain a Transfer log matching request parameters"
           end
+          assert_challenge_bound_memo(matched_logs, credential.challenge) unless request.method_details.memo
 
           Mpp::Receipt.success(tx_hash)
         end
 
         def verify_transfer_logs(receipt, request, expected_sender: nil)
+          match_transfer_logs(receipt, request, expected_sender: expected_sender).any?
+        end
+
+        def match_transfer_logs(receipt, request, expected_sender: nil)
           expected_memo = request.method_details.memo
+          matched_logs = []
 
           (receipt["logs"] || []).each do |log|
             next unless log["address"]&.downcase == request.currency.downcase
@@ -164,19 +169,42 @@ module Mpp
               memo = topics[3]
               memo_clean = expected_memo.downcase
               memo_clean = "0x#{memo_clean}" unless memo_clean.start_with?("0x")
-              return true if amount == Integer(request.amount) && memo.downcase == memo_clean
+              if amount == Integer(request.amount) && memo.downcase == memo_clean
+                matched_logs << {kind: :memo, memo: memo}
+              end
             else
-              next unless topics[0] == TRANSFER_TOPIC
+              case topics[0]
+              when TRANSFER_WITH_MEMO_TOPIC
+                next if topics.length < 4
 
-              data = log.fetch("data", "0x")
-              next if data.length < 66
+                data = log.fetch("data", "0x")
+                next if data.length < 66
 
-              amount = data.delete_prefix("0x").to_i(16)
-              return true if amount == Integer(request.amount)
+                amount = data[2, 64].to_i(16)
+                matched_logs << {kind: :memo, memo: topics[3]} if amount == Integer(request.amount)
+              when TRANSFER_TOPIC
+                data = log.fetch("data", "0x")
+                next if data.length < 66
+
+                amount = data.delete_prefix("0x").to_i(16)
+                matched_logs << {kind: :transfer} if amount == Integer(request.amount)
+              end
             end
           end
 
-          false
+          matched_logs.sort_by { |log| (log[:kind] == :memo) ? 0 : 1 }
+        end
+
+        def assert_challenge_bound_memo(matched_logs, challenge)
+          bound = matched_logs.any? do |log|
+            log[:kind] == :memo &&
+              Attribution.verify_server(log[:memo], challenge.realm) &&
+              Attribution.verify_challenge_binding(log[:memo], challenge.id)
+          end
+
+          return if bound
+
+          raise Mpp::VerificationError, "Payment verification failed: memo is not bound to this challenge"
         end
 
         def validate_transaction_payload(signature, request)

--- a/test/mpp/methods/tempo/test_attribution.rb
+++ b/test/mpp/methods/tempo/test_attribution.rb
@@ -86,6 +86,7 @@ class TestAttribution < Minitest::Test
     d2 = Mpp::Methods::Tempo::Attribution.decode(m2)
 
     assert_equal d1.nonce, d2.nonce
+    assert Mpp::Methods::Tempo::Attribution.verify_challenge_binding(m1, "chal-123")
   end
 
   def test_encode_with_different_challenge_ids
@@ -96,6 +97,7 @@ class TestAttribution < Minitest::Test
     d2 = Mpp::Methods::Tempo::Attribution.decode(m2)
 
     refute_equal d1.nonce, d2.nonce
+    refute Mpp::Methods::Tempo::Attribution.verify_challenge_binding(m1, "chal-b")
   end
 
   def test_encode_without_challenge_id_is_random

--- a/test/mpp/methods/tempo/test_charge_intent.rb
+++ b/test/mpp/methods/tempo/test_charge_intent.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestTempoChargeIntent < Minitest::Test
+  CURRENCY = "0x20c0000000000000000000000000000000000000"
+  HASH = "0xabc123"
+  REALM = "api.example.com"
+  RECIPIENT = "0x1234567890abcdef1234567890abcdef12345678"
+  SENDER = "0x0000000000000000000000000000000000000001"
+
+  def setup
+    @intent = Mpp::Methods::Tempo::ChargeIntent.new(rpc_url: "https://rpc.example.test")
+  end
+
+  def test_hash_without_explicit_memo_accepts_challenge_bound_attribution_memo
+    memo = Mpp::Methods::Tempo::Attribution.encode(
+      server_id: REALM,
+      challenge_id: "challenge-123"
+    )
+
+    receipt = receipt([transfer_log(memo: memo), transfer_log])
+
+    result = verify_hash(receipt, challenge_id: "challenge-123")
+
+    assert_equal HASH, result.reference
+  end
+
+  def test_hash_without_explicit_memo_rejects_plain_transfer
+    error = assert_raises(Mpp::VerificationError) do
+      verify_hash(receipt([transfer_log]), challenge_id: "challenge-123")
+    end
+
+    assert_match(/memo is not bound to this challenge/, error.message)
+  end
+
+  def test_hash_without_explicit_memo_rejects_wrong_challenge_nonce
+    memo = Mpp::Methods::Tempo::Attribution.encode(
+      server_id: REALM,
+      challenge_id: "challenge-abc"
+    )
+
+    error = assert_raises(Mpp::VerificationError) do
+      verify_hash(receipt([transfer_log(memo: memo), transfer_log]), challenge_id: "challenge-xyz")
+    end
+
+    assert_match(/memo is not bound to this challenge/, error.message)
+  end
+
+  def test_hash_without_explicit_memo_rejects_wrong_realm
+    memo = Mpp::Methods::Tempo::Attribution.encode(
+      server_id: "other.example.com",
+      challenge_id: "challenge-123"
+    )
+
+    error = assert_raises(Mpp::VerificationError) do
+      verify_hash(receipt([transfer_log(memo: memo), transfer_log]), challenge_id: "challenge-123")
+    end
+
+    assert_match(/memo is not bound to this challenge/, error.message)
+  end
+
+  def test_hash_with_explicit_memo_accepts_exact_memo
+    explicit_memo = "0x#{"ab" * 32}"
+    result = verify_hash(
+      receipt([transfer_log(memo: explicit_memo)]),
+      challenge_id: "challenge-123",
+      memo: explicit_memo
+    )
+
+    assert_equal HASH, result.reference
+  end
+
+  private
+
+  def verify_hash(receipt, challenge_id:, memo: nil)
+    credential = Mpp::Credential.new(
+      challenge: Mpp::ChallengeEcho.new(
+        id: challenge_id,
+        realm: REALM,
+        method: "tempo",
+        intent: "charge",
+        request: ""
+      ),
+      payload: {"type" => "hash", "hash" => HASH}
+    )
+
+    Mpp::Methods::Tempo::Rpc.stub(:call, ->(_rpc_url, method, params) {
+      assert_equal "eth_getTransactionReceipt", method
+      assert_equal [HASH], params
+      receipt
+    }) do
+      @intent.verify(credential, request_hash(memo: memo))
+    end
+  end
+
+  def request_hash(memo: nil)
+    request = {
+      "amount" => "1000",
+      "currency" => CURRENCY,
+      "recipient" => RECIPIENT
+    }
+    request["methodDetails"] = {"memo" => memo} if memo
+    request
+  end
+
+  def receipt(logs)
+    {"status" => "0x1", "from" => SENDER, "logs" => logs}
+  end
+
+  def transfer_log(memo: nil)
+    topics = [
+      memo ? Mpp::Methods::Tempo::TRANSFER_WITH_MEMO_TOPIC : Mpp::Methods::Tempo::TRANSFER_TOPIC,
+      topic_address(SENDER),
+      topic_address(RECIPIENT)
+    ]
+    topics << memo if memo
+
+    {
+      "address" => CURRENCY,
+      "topics" => topics,
+      "data" => "0x#{1000.to_s(16).rjust(64, "0")}"
+    }
+  end
+
+  def topic_address(address)
+    "0x#{address.delete_prefix("0x").rjust(64, "0")}"
+  end
+end


### PR DESCRIPTION
## Summary
- verify default Tempo attribution memos are bound to the credential challenge before accepting hash credentials
- preserve matched TransferWithMemo logs so memo binding is checked on the payment log instead of accepting the paired plain Transfer event
- add focused tests for plain transfers, wrong challenge nonce, wrong realm, and explicit memo behavior