### PR TITLE
add live tempo integration coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,49 @@ jobs:
           ruby-version: "3.3"
           bundler-cache: true
       - run: bundle exec rake test
+
+  integration:
+    runs-on: ubuntu-latest
+    env:
+      TEMPO_TAG: latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+
+      - name: Resolve Tempo image digest
+        id: tempo-digest
+        run: |
+          digest=$(docker buildx imagetools inspect ghcr.io/tempoxyz/tempo:${TEMPO_TAG} --raw | sha256sum | cut -d' ' -f1)
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Tempo Docker image
+        uses: actions/cache@v4
+        id: docker-cache
+        with:
+          path: /tmp/tempo-image.tar
+          key: tempo-image-${{ steps.tempo-digest.outputs.digest }}
+
+      - name: Load cached Tempo image
+        if: steps.docker-cache.outputs.cache-hit == 'true'
+        run: docker load -i /tmp/tempo-image.tar
+
+      - name: Pull and cache Tempo image
+        if: steps.docker-cache.outputs.cache-hit != 'true'
+        run: |
+          docker pull ghcr.io/tempoxyz/tempo:${TEMPO_TAG}
+          docker save ghcr.io/tempoxyz/tempo:${TEMPO_TAG} -o /tmp/tempo-image.tar
+
+      - name: Start Tempo devnet
+        run: docker compose up -d --wait
+
+      - name: Run integration tests
+        run: bundle exec rake test:integration
+        env:
+          TEMPO_RPC_URL: http://localhost:8545
+
+      - name: Stop Tempo devnet
+        if: always()
+        run: docker compose down

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,10 @@ source "https://rubygems.org"
 gemspec
 
 group :development, :test do
+  gem "eth", "~> 0.5"
   gem "minitest", "~> 5.25"
   gem "minitest-reporters", "~> 1.7"
+  gem "rlp", "~> 0.7"
   gem "rake", "~> 13.0"
   gem "standard", "~> 1.44"
   gem "sorbet-static-and-runtime"
@@ -17,6 +19,4 @@ end
 # Optional runtime dependencies (autoloaded)
 # gem "async", "~> 2.0", require: false
 # gem "async-http", "~> 0.75", require: false
-# gem "eth", "~> 0.5", require: false
-# gem "rlp", "~> 0.7", require: false
 gem "stripe", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,17 +13,46 @@ GEM
     ast (2.4.3)
     base64 (0.3.0)
     benchmark (0.5.0)
-    bigdecimal (4.0.1)
+    bigdecimal (3.3.1)
+    bls12-381 (0.3.1)
+      bigdecimal
+      h2c (>= 0.2.1, < 0.3)
     builder (3.3.0)
     crack (1.0.1)
       bigdecimal
       rexml
+    ecdsa (1.2.0)
     erubi (1.13.1)
+    eth (0.5.17)
+      base64 (~> 0.1)
+      bigdecimal (~> 3.1)
+      bls12-381 (~> 0.3)
+      forwardable (~> 1.3)
+      httpx (~> 1.6)
+      keccak (~> 1.3)
+      konstructor (~> 1.0)
+      openssl (~> 3.3)
+      rbsecp256k1 (~> 6.0)
+      scrypt (~> 3.0)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
+    ffi-compiler (1.4.2)
+      ffi (>= 1.15.5)
+      rake
+    forwardable (1.4.0)
+    h2c (0.2.1)
+      ecdsa (~> 1.2.0)
     hashdiff (1.2.1)
+    http-2 (1.1.3)
+    httpx (1.7.6)
+      http-2 (>= 1.1.3)
     json (2.19.3)
+    keccak (1.3.3)
+    konstructor (1.0.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
+    mini_portile2 (2.8.9)
     minitest (5.27.0)
     minitest-reporters (1.7.1)
       ansi
@@ -31,10 +60,12 @@ GEM
       minitest (>= 5.0)
       ruby-progressbar
     netrc (0.11.0)
+    openssl (3.3.2)
     parallel (1.27.0)
     parser (3.3.10.2)
       ast (~> 2.4.1)
       racc
+    pkg-config (1.6.5)
     prism (1.9.0)
     public_suffix (7.0.5)
     racc (1.8.1)
@@ -47,9 +78,14 @@ GEM
       logger
       prism (>= 1.6.0)
       tsort
+    rbsecp256k1 (6.0.0)
+      mini_portile2 (~> 2.8)
+      pkg-config (~> 1.5)
+      rubyzip (~> 2.3)
     regexp_parser (2.11.3)
     require-hooks (0.2.3)
     rexml (3.4.4)
+    rlp (0.7.3)
     rubocop (1.84.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -69,6 +105,10 @@ GEM
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
     ruby-progressbar (1.13.0)
+    rubyzip (2.4.1)
+    scrypt (3.1.0)
+      ffi-compiler (>= 1.0, < 2.0)
+      rake (~> 13)
     sorbet (0.6.13059)
       sorbet-static (= 0.6.13059)
     sorbet-runtime (0.6.13059)
@@ -127,14 +167,17 @@ GEM
       yard
 
 PLATFORMS
+  arm64-darwin-24
   arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES
+  eth (~> 0.5)
   minitest (~> 5.25)
   minitest-reporters (~> 1.7)
   mpp-rb!
   rake (~> 13.0)
+  rlp (~> 0.7)
   sorbet-static-and-runtime
   standard (~> 1.44)
   stripe

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,16 @@
-.PHONY: test lint format typecheck ci
+.PHONY: test test-integration node node-stop lint format typecheck ci
 
 test:
 	bundle exec rake test
+
+test-integration:
+	TEMPO_RPC_URL=$${TEMPO_RPC_URL:-http://localhost:8545} bundle exec rake test:integration
+
+node:
+	docker compose up -d --wait
+
+node-stop:
+	docker compose down
 
 lint:
 	bundle exec standardrb

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,15 @@ require "rake/testtask"
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
-  t.test_files = FileList["test/**/test_*.rb"]
+  t.test_files = FileList["test/**/test_*.rb"].exclude("test/integration/**/*")
+end
+
+namespace :test do
+  Rake::TestTask.new(:integration) do |t|
+    t.libs << "test"
+    t.libs << "lib"
+    t.test_files = FileList["test/integration/**/*_test.rb"]
+  end
 end
 
 task default: :test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  tempo:
+    image: ghcr.io/tempoxyz/tempo:${TEMPO_TAG:-latest}
+    platform: linux/amd64
+    ports:
+      - "8545:8545"
+    command: >
+      node
+      --dev
+      --dev.block-time 200ms
+      --http
+      --http.addr 0.0.0.0
+      --http.port 8545
+      --http.api all
+      --http.corsdomain '*'
+      --engine.legacy-state-root
+      --engine.disable-precompile-cache
+      --faucet.enabled
+      --faucet.private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+      --faucet.amount 1000000000000000
+      --faucet.address 0x20c0000000000000000000000000000000000000
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'echo >/dev/tcp/localhost/8545' 2>/dev/null || exit 1"]
+      interval: 2s
+      timeout: 5s
+      retries: 30

--- a/lib/mpp/methods/tempo/fee_payer_envelope.rb
+++ b/lib/mpp/methods/tempo/fee_payer_envelope.rb
@@ -17,8 +17,8 @@ module Mpp
           Kernel.require "rlp"
 
           sender_sig = signed_tx.sender_signature
-          sig_bytes = sender_sig.respond_to?(:to_bytes) ? sender_sig.to_bytes : sender_sig.to_s.b
-          sender_addr = signed_tx.sender_address.to_s.b
+          sig_bytes = normalize_signature(sender_sig.respond_to?(:to_bytes) ? sender_sig.to_bytes : sender_sig.to_s.b)
+          sender_addr = pack_hex(signed_tx.sender_address)
 
           fields = [
             signed_tx.chain_id,
@@ -26,12 +26,12 @@ module Mpp
             signed_tx.max_fee_per_gas,
             signed_tx.gas_limit,
             signed_tx.calls.map(&:as_rlp_list),
-            signed_tx.access_list.map(&:as_rlp_list),
+            signed_tx.access_list.map { |entry| entry.respond_to?(:as_rlp_list) ? entry.as_rlp_list : entry },
             signed_tx.nonce_key,
             signed_tx.nonce,
             encode_optional_uint(signed_tx.valid_before),
             encode_optional_uint(signed_tx.valid_after),
-            signed_tx.fee_token ? signed_tx.fee_token.to_s.b : "".b,
+            signed_tx.fee_token ? pack_hex(signed_tx.fee_token) : "".b,
             sender_addr,
             signed_tx.tempo_authorization_list.to_a
           ]
@@ -39,7 +39,7 @@ module Mpp
           fields << RLP.decode(signed_tx.key_authorization) if signed_tx.key_authorization
           fields << sig_bytes
 
-          [TYPE_ID].pack("C") + RLP.include(fields)
+          [TYPE_ID].pack("C") + RLP.encode(fields)
         end
 
         # Decode a 0x78 fee payer envelope.
@@ -58,7 +58,7 @@ module Mpp
 
           # 15 fields = key_authorization present (index 13), signature at 14
           # 14 fields = no key_authorization, signature at 13
-          key_authorization = (RLP.include(decoded[13]) if decoded.length == 15)
+          key_authorization = (RLP.encode(decoded[13]) if decoded.length == 15)
 
           [decoded, sender_address.to_s.b, sender_signature.to_s.b, key_authorization]
         end
@@ -67,6 +67,21 @@ module Mpp
           return "".b unless value
 
           value.is_a?(Integer) ? value : value.to_i
+        end
+
+        def pack_hex(value)
+          [value.to_s.delete_prefix("0x")].pack("H*")
+        end
+
+        def normalize_signature(signature)
+          bytes = signature.b
+          Kernel.raise ArgumentError, "signature must be 65 bytes, got #{bytes.bytesize}" unless bytes.bytesize == 65
+
+          v = bytes.getbyte(64)
+          parity = (v >= 27) ? v - 27 : v
+          Kernel.raise ArgumentError, "signature parity must be 0 or 1, got #{v}" unless [0, 1].include?(parity)
+
+          bytes[0, 64] + [parity].pack("C")
         end
       end
     end

--- a/lib/mpp/methods/tempo/intents.rb
+++ b/lib/mpp/methods/tempo/intents.rb
@@ -335,7 +335,7 @@ module Mpp
             max_fee_per_gas: int.call(decoded[2]),
             gas_limit: int.call(decoded[3]),
             calls: calls,
-            access_list: Transaction::EMPTY_LIST,
+            access_list: decoded[5] || Transaction::EMPTY_LIST,
             nonce_key: int.call(decoded[6]),
             nonce: int.call(decoded[7]),
             valid_before: int.call(decoded[8]),
@@ -350,7 +350,7 @@ module Mpp
 
           # Verify sender signature
           sender_hash = tx_for_recovery.signature_hash
-          recovered = Eth::Key.personal_recover(sender_hash, "0x#{sender_sig.unpack1("H*")}")
+          recovered = Eth::Signature.recover(sender_hash, "0x#{sender_sig.unpack1("H*")}")
           recovered_addr = Eth::Util.public_key_to_address(recovered).to_s
           envelope_addr = "0x#{sender_addr_bytes.unpack1("H*")}"
 
@@ -364,7 +364,7 @@ module Mpp
 
           tx_to_sign = tx_for_recovery.with(fee_token: resolved_fee_token)
 
-          # Fee payer signs over fields including sender_signature
+          # Fee payer signs the 0x78 payload, which identifies the recovered sender.
           fee_payer_hash = tx_to_sign.fee_payer_signature_hash
           fee_payer_sig = fee_payer.sign_hash(fee_payer_hash)
 

--- a/lib/mpp/methods/tempo/transaction.rb
+++ b/lib/mpp/methods/tempo/transaction.rb
@@ -45,7 +45,7 @@ module Mpp
             require_eth!
             require_rlp!
 
-            Eth::Util.keccak256([TYPE_ID].pack("C") + RLP.encode(unsigned_rlp_fields))
+            Eth::Util.keccak256([TYPE_ID].pack("C") + RLP.encode(signing_rlp_fields))
           end
 
           # Hash for fee payer to sign — includes sender_signature in the RLP.
@@ -61,14 +61,19 @@ module Mpp
           private
 
           def rlp_fields
+            fields = signing_rlp_fields
+            fields << signature_envelope(sender_signature) if sender_signature
+            fields
+          end
+
+          def signing_rlp_fields
             fields = unsigned_rlp_fields
-            fields.insert(11, sender_signature)
-            fields.insert(12, fee_payer_signature || EMPTY_SIGNATURE)
+            fields << key_authorization if key_authorization
             fields
           end
 
           def unsigned_rlp_fields
-            fields = [
+            [
               chain_id,
               max_priority_fee_per_gas,
               max_fee_per_gas,
@@ -80,10 +85,44 @@ module Mpp
               encode_optional_uint(valid_before),
               encode_optional_uint(valid_after),
               fee_token ? pack_hex(fee_token) : "".b,
+              fee_payer_field,
               tempo_authorization_list || EMPTY_LIST
             ]
-            fields << key_authorization if key_authorization
-            fields
+          end
+
+          def fee_payer_field
+            return signature_tuple(fee_payer_signature) if fee_payer_signature && fee_payer_signature != EMPTY_SIGNATURE
+            return EMPTY_SIGNATURE if fee_token.nil?
+
+            "".b
+          end
+
+          def signature_tuple(signature)
+            normalized = normalized_signature(signature)
+            [
+              normalized.getbyte(64).zero? ? "".b : normalized[64],
+              trim_leading_zeroes(normalized[0, 32]),
+              trim_leading_zeroes(normalized[32, 32])
+            ]
+          end
+
+          def signature_envelope(signature)
+            normalized_signature(signature)
+          end
+
+          def normalized_signature(signature)
+            bytes = signature.b
+            raise ArgumentError, "signature must be 65 bytes, got #{bytes.bytesize}" unless bytes.bytesize == 65
+
+            v = bytes.getbyte(64)
+            parity = (v >= 27) ? v - 27 : v
+            raise ArgumentError, "signature parity must be 0 or 1, got #{v}" unless [0, 1].include?(parity)
+
+            bytes[0, 64] + [parity].pack("C")
+          end
+
+          def trim_leading_zeroes(value)
+            value.sub(/\A\x00+/n, "")
           end
 
           def pack_hex(value)

--- a/lib/mpp/methods/tempo/transaction.rb
+++ b/lib/mpp/methods/tempo/transaction.rb
@@ -48,14 +48,12 @@ module Mpp
             Eth::Util.keccak256([TYPE_ID].pack("C") + RLP.encode(signing_rlp_fields))
           end
 
-          # Hash for fee payer to sign — includes sender_signature in the RLP.
+          # Hash for fee payer to sign.
           def fee_payer_signature_hash
             require_eth!
             require_rlp!
 
-            fields = unsigned_rlp_fields
-            fields.insert(11, sender_signature)
-            Eth::Util.keccak256([TYPE_ID].pack("C") + RLP.encode(fields))
+            Eth::Util.keccak256([FeePayer::TYPE_ID].pack("C") + RLP.encode(fee_payer_signing_rlp_fields))
           end
 
           private
@@ -88,6 +86,26 @@ module Mpp
               fee_payer_field,
               tempo_authorization_list || EMPTY_LIST
             ]
+          end
+
+          def fee_payer_signing_rlp_fields
+            fields = [
+              chain_id,
+              max_priority_fee_per_gas,
+              max_fee_per_gas,
+              gas_limit,
+              calls.map(&:as_rlp_list),
+              access_list || EMPTY_LIST,
+              nonce_key,
+              nonce,
+              encode_optional_uint(valid_before),
+              encode_optional_uint(valid_after),
+              fee_token ? pack_hex(fee_token) : "".b,
+              pack_hex(sender_address),
+              tempo_authorization_list || EMPTY_LIST
+            ]
+            fields << key_authorization if key_authorization
+            fields
           end
 
           def fee_payer_field

--- a/sorbet/rbi/shims/eth.rbi
+++ b/sorbet/rbi/shims/eth.rbi
@@ -13,4 +13,8 @@ module Eth
     def sign(data); end
     def self.personal_recover(data, signature); end
   end
+
+  module Signature
+    def self.recover(data, signature); end
+  end
 end

--- a/test/integration/tempo_live_test.rb
+++ b/test/integration/tempo_live_test.rb
@@ -41,7 +41,23 @@ class TempoLiveIntegrationTest < Minitest::Test
 
     response = Mpp::Client.get(server.url, methods: [client_method(account: payer)])
 
-    assert_equal "200", response.code
+    assert_equal "200", response.code, response.body
+    refute_nil response["Payment-Receipt"]
+    body = JSON.parse(response.body)
+    assert_equal "paid", body.fetch("status")
+  ensure
+    server&.close
+  end
+
+  def test_client_transport_completes_fee_payer_402_roundtrip
+    payer = funded_account
+    recipient = funded_account
+    fee_payer = funded_account
+    server = PaidServer.new(recipient: recipient.address, chain_id: chain_id, fee_payer: fee_payer)
+
+    response = Mpp::Client.get(server.url, methods: [client_method(account: payer)])
+
+    assert_equal "200", response.code, response.body
     refute_nil response["Payment-Receipt"]
     body = JSON.parse(response.body)
     assert_equal "paid", body.fetch("status")
@@ -233,14 +249,16 @@ class TempoLiveIntegrationTest < Minitest::Test
   class PaidServer
     attr_reader :url
 
-    def initialize(recipient:, chain_id:)
+    def initialize(recipient:, chain_id:, fee_payer: nil)
       method = Mpp::Methods::Tempo.tempo(
         chain_id: chain_id,
         rpc_url: RPC_URL,
         currency: CURRENCY,
         recipient: recipient,
+        fee_payer: fee_payer,
         intents: {"charge" => Mpp::Methods::Tempo::ChargeIntent.new(rpc_url: RPC_URL)}
       )
+      @sponsored = !fee_payer.nil?
       @handler = Mpp.create(method: method, realm: REALM, secret_key: SECRET_KEY)
       @memo = Mpp::Methods::Tempo::Attribution.encode(server_id: REALM, challenge_id: SecureRandom.hex(6))
       @server = TCPServer.new("127.0.0.1", 0)
@@ -277,7 +295,13 @@ class TempoLiveIntegrationTest < Minitest::Test
         headers[key.downcase] = value.strip if key && value
       end
 
-      result = @handler.charge(headers["authorization"], "1.00", chain_id: chain_id, memo: @memo)
+      result = @handler.charge(
+        headers["authorization"],
+        "1.00",
+        chain_id: chain_id,
+        memo: @memo,
+        fee_payer: @sponsored
+      )
       if result.is_a?(Mpp::Challenge)
         response = Mpp::Server::Decorator.make_challenge_response(result, @handler.realm)
         write_response(socket, response["status"], response["headers"], response["body"])

--- a/test/integration/tempo_live_test.rb
+++ b/test/integration/tempo_live_test.rb
@@ -1,0 +1,312 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "json"
+require "net/http"
+require "securerandom"
+require "socket"
+
+class TempoLiveIntegrationTest < Minitest::Test
+  RPC_URL = ENV.fetch("TEMPO_RPC_URL", "http://localhost:8545")
+  REALM = "mpp-rb.local"
+  SECRET_KEY = "integration-secret"
+  CURRENCY = Mpp::Methods::Tempo::Defaults::PATH_USD
+  FUNDING_TIMEOUT = 45
+  RECEIPT_TIMEOUT = 45
+
+  def setup
+    skip "TEMPO_RPC_URL not set" unless ENV["TEMPO_RPC_URL"]
+
+    wait_for_rpc
+  end
+
+  def test_transaction_credential_verifies_against_live_node
+    payer = funded_account
+    recipient = funded_account
+    memo = Mpp::Methods::Tempo::Attribution.encode(server_id: REALM, challenge_id: "tx-#{SecureRandom.hex(6)}")
+    challenge = challenge_for(recipient: recipient.address, memo: memo)
+
+    credential = client_method(account: payer).create_credential(challenge)
+    receipt = charge_intent.verify(credential, challenge.request)
+
+    assert_equal "success", receipt.status
+    assert_equal "tempo", receipt.method
+    assert_match(/\A0x[0-9a-fA-F]{64}\z/, receipt.reference)
+  end
+
+  def test_client_transport_completes_402_roundtrip
+    payer = funded_account
+    recipient = funded_account
+    server = PaidServer.new(recipient: recipient.address, chain_id: chain_id)
+
+    response = Mpp::Client.get(server.url, methods: [client_method(account: payer)])
+
+    assert_equal "200", response.code
+    refute_nil response["Payment-Receipt"]
+    body = JSON.parse(response.body)
+    assert_equal "paid", body.fetch("status")
+  ensure
+    server&.close
+  end
+
+  def test_hash_credential_verifies_live_transfer
+    payer = funded_account
+    recipient = funded_account
+    memo = Mpp::Methods::Tempo::Attribution.encode(server_id: REALM, challenge_id: "hash-#{SecureRandom.hex(6)}")
+    challenge = challenge_for(recipient: recipient.address, memo: memo)
+    tx_hash = send_transfer(
+      account: payer,
+      recipient: recipient.address,
+      amount: 1_000_000,
+      memo: memo
+    )
+    credential = Mpp::Credential.new(
+      challenge: challenge.to_echo,
+      payload: {"type" => "hash", "hash" => tx_hash},
+      source: "did:pkh:eip155:#{chain_id}:#{payer.address}"
+    )
+
+    receipt = charge_intent.verify(credential, challenge.request)
+
+    assert_equal "success", receipt.status
+    assert_equal tx_hash, receipt.reference
+  end
+
+  def test_hash_credential_replay_rejected_with_store
+    payer = funded_account
+    recipient = funded_account
+    memo = Mpp::Methods::Tempo::Attribution.encode(server_id: REALM, challenge_id: "replay-#{SecureRandom.hex(6)}")
+    challenge = challenge_for(recipient: recipient.address, memo: memo)
+    tx_hash = send_transfer(
+      account: payer,
+      recipient: recipient.address,
+      amount: 1_000_000,
+      memo: memo
+    )
+    credential = Mpp::Credential.new(
+      challenge: challenge.to_echo,
+      payload: {"type" => "hash", "hash" => tx_hash},
+      source: "did:pkh:eip155:#{chain_id}:#{payer.address}"
+    )
+    intent = charge_intent(store: Mpp::MemoryStore.new)
+
+    receipt = intent.verify(credential, challenge.request)
+    assert_equal "success", receipt.status
+
+    error = assert_raises(Mpp::VerificationError) do
+      intent.verify(credential, challenge.request)
+    end
+    assert_match(/already used/, error.message)
+  end
+
+  private
+
+  def chain_id
+    @chain_id ||= rpc("eth_chainId").to_i(16)
+  end
+
+  def wait_for_rpc
+    deadline = Time.now + 45
+    loop do
+      begin
+        return if rpc("eth_chainId")
+      rescue
+        nil
+      end
+
+      raise "Tempo RPC at #{RPC_URL} did not become ready" if Time.now >= deadline
+
+      sleep 0.5
+    end
+  end
+
+  def rpc(method, params = [])
+    Mpp::Methods::Tempo::Rpc.call(RPC_URL, method, params)
+  end
+
+  def funded_account
+    account = Mpp::Methods::Tempo::Account.from_key("0x#{SecureRandom.hex(32)}")
+    fund_account(account.address)
+    account
+  end
+
+  def fund_account(address)
+    result = rpc("tempo_fundAddress", [address])
+    wait_for_receipt(result) if result.is_a?(String) && !result.empty?
+    wait_for_balance(address)
+  rescue => _e
+    wait_for_balance(address)
+  end
+
+  def wait_for_balance(address)
+    deadline = Time.now + FUNDING_TIMEOUT
+    loop do
+      return if token_balance(address).positive?
+
+      raise "Account #{address} was not funded" if Time.now >= deadline
+
+      sleep 0.5
+    end
+  end
+
+  def token_balance(address)
+    data = "0x70a08231#{address.delete_prefix("0x").downcase.rjust(64, "0")}"
+    rpc("eth_call", [{"to" => CURRENCY, "data" => data}, "latest"]).to_i(16)
+  end
+
+  def wait_for_receipt(tx_hash)
+    deadline = Time.now + RECEIPT_TIMEOUT
+    loop do
+      receipt = rpc("eth_getTransactionReceipt", [tx_hash])
+      return receipt if receipt && receipt["status"] == "0x1"
+      raise "Transaction #{tx_hash} did not succeed" if receipt
+      raise "Receipt not found for #{tx_hash}" if Time.now >= deadline
+
+      sleep 0.5
+    end
+  end
+
+  def send_transfer(account:, recipient:, amount:, memo:)
+    raw_tx = build_raw_transfer(account: account, recipient: recipient, amount: amount, memo: memo)
+    tx_hash = rpc("eth_sendRawTransaction", [raw_tx])
+    wait_for_receipt(tx_hash)
+    tx_hash
+  end
+
+  def build_raw_transfer(account:, recipient:, amount:, memo:)
+    tx_params = Mpp::Methods::Tempo::Rpc.get_tx_params(RPC_URL, account.address)
+    chain_id, nonce, gas_price = tx_params
+    data = encode_transfer_with_memo(recipient, amount, memo)
+
+    raw_tx, = Mpp::Methods::Tempo::Transaction.build_signed_transfer(
+      account: account,
+      chain_id: chain_id,
+      gas_limit: 1_000_000,
+      gas_price: gas_price,
+      nonce: nonce,
+      nonce_key: 0,
+      currency: CURRENCY,
+      transfer_data: data
+    )
+    raw_tx
+  end
+
+  def encode_transfer_with_memo(recipient, amount, memo)
+    to_padded = recipient.delete_prefix("0x").downcase.rjust(64, "0")
+    amount_padded = amount.to_s(16).rjust(64, "0")
+    memo_clean = memo.delete_prefix("0x").downcase
+    "0x95777d59#{to_padded}#{amount_padded}#{memo_clean}"
+  end
+
+  def client_method(account:)
+    Mpp::Methods::Tempo.tempo(
+      account: account,
+      chain_id: chain_id,
+      rpc_url: RPC_URL,
+      intents: {"charge" => Mpp::Methods::Tempo::ChargeIntent.new}
+    )
+  end
+
+  def charge_intent(store: nil)
+    Mpp::Methods::Tempo::ChargeIntent.new(rpc_url: RPC_URL, store: store)
+  end
+
+  def challenge_for(recipient:, memo: nil)
+    method_details = {"chainId" => chain_id}
+    method_details["memo"] = memo if memo
+
+    Mpp::Challenge.create(
+      secret_key: SECRET_KEY,
+      realm: REALM,
+      method: "tempo",
+      intent: "charge",
+      request: {
+        "amount" => "1000000",
+        "currency" => CURRENCY,
+        "recipient" => recipient,
+        "methodDetails" => method_details
+      },
+      expires: Mpp::Expires.minutes(5)
+    )
+  end
+
+  class PaidServer
+    attr_reader :url
+
+    def initialize(recipient:, chain_id:)
+      method = Mpp::Methods::Tempo.tempo(
+        chain_id: chain_id,
+        rpc_url: RPC_URL,
+        currency: CURRENCY,
+        recipient: recipient,
+        intents: {"charge" => Mpp::Methods::Tempo::ChargeIntent.new(rpc_url: RPC_URL)}
+      )
+      @handler = Mpp.create(method: method, realm: REALM, secret_key: SECRET_KEY)
+      @memo = Mpp::Methods::Tempo::Attribution.encode(server_id: REALM, challenge_id: SecureRandom.hex(6))
+      @server = TCPServer.new("127.0.0.1", 0)
+      @url = "http://127.0.0.1:#{@server.addr[1]}/paid"
+      @thread = Thread.new { serve }
+    end
+
+    def close
+      @server.close
+      @thread.join(2)
+    end
+
+    private
+
+    def serve
+      loop do
+        socket = @server.accept
+        handle(socket)
+      rescue IOError
+        break
+      end
+    end
+
+    def handle(socket)
+      request_line = socket.gets
+      return unless request_line
+
+      headers = {}
+      while (line = socket.gets)
+        line = line.strip
+        break if line.empty?
+
+        key, value = line.split(":", 2)
+        headers[key.downcase] = value.strip if key && value
+      end
+
+      result = @handler.charge(headers["authorization"], "1.00", chain_id: chain_id, memo: @memo)
+      if result.is_a?(Mpp::Challenge)
+        response = Mpp::Server::Decorator.make_challenge_response(result, @handler.realm)
+        write_response(socket, response["status"], response["headers"], response["body"])
+      else
+        _credential, receipt = result
+        body = JSON.generate({"status" => "paid"})
+        write_response(socket, 200, {
+          "Content-Type" => "application/json",
+          "Payment-Receipt" => receipt.to_payment_receipt
+        }, body)
+      end
+    rescue => e
+      write_response(socket, 500, {"Content-Type" => "text/plain"}, e.message)
+    ensure
+      socket&.close
+    end
+
+    def chain_id
+      @handler.method.chain_id
+    end
+
+    def write_response(socket, status, headers, body)
+      reason = (status == 200) ? "OK" : "Payment Required"
+      socket.write("HTTP/1.1 #{status} #{reason}\r\n")
+      headers.each { |key, value| socket.write("#{key}: #{value}\r\n") }
+      socket.write("Content-Length: #{body.bytesize}\r\n")
+      socket.write("Connection: close\r\n")
+      socket.write("\r\n")
+      socket.write(body)
+    end
+  end
+end

--- a/test/mpp/methods/tempo/test_transaction.rb
+++ b/test/mpp/methods/tempo/test_transaction.rb
@@ -3,11 +3,15 @@
 require "test_helper"
 
 class TestTempoTransaction < Minitest::Test
-  FakeAccount = Struct.new(:address) do
+  FakeAccount = Struct.new(:address, :signature) do
     def sign_hash(_digest)
-      "\x33" * 65
+      signature || ("\x33" * 64 + "\x1b")
     end
   end
+
+  CURRENCY = "0x20c0000000000000000000000000000000000000"
+  RECIPIENT = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
+  ACCOUNT = "0x1234567890abcdef1234567890abcdef12345678"
 
   def test_build_signed_transfer_requires_eth_and_rlp
     original_require = Kernel.method(:require)
@@ -24,7 +28,7 @@ class TestTempoTransaction < Minitest::Test
           gas_price: 1,
           nonce: 0,
           nonce_key: 0,
-          currency: Mpp::Methods::Tempo::Defaults::PATH_USD,
+          currency: CURRENCY,
           transfer_data: "0xa9059cbb" + ("0" * 128),
           awaiting_fee_payer: false
         )
@@ -32,5 +36,183 @@ class TestTempoTransaction < Minitest::Test
 
       assert_includes error.message, "eth gem"
     end
+  end
+
+  def test_signed_transfer_places_sender_signature_in_final_envelope
+    skip "eth/rlp gems not available" unless eth_and_rlp_available?
+
+    raw_tx, chain_id = Mpp::Methods::Tempo::Transaction.build_signed_transfer(
+      account: FakeAccount.new(ACCOUNT, "\x11" * 64 + "\x1b"),
+      chain_id: 42_431,
+      gas_limit: 1_000_000,
+      gas_price: 1,
+      nonce: 0,
+      nonce_key: 0,
+      currency: CURRENCY,
+      transfer_data: transfer_data,
+      awaiting_fee_payer: false
+    )
+
+    assert_equal 42_431, chain_id
+    decoded = decode_raw_tx(raw_tx, 0x76)
+
+    assert_equal 14, decoded.length
+    assert_equal CURRENCY.downcase.delete_prefix("0x"), decoded[10].unpack1("H*")
+    assert_equal "", decoded[11]
+    assert_equal [], decoded[12]
+    assert_equal "\x11" * 64 + "\x00", decoded[13]
+  end
+
+  def test_awaiting_fee_payer_builds_decodable_0x78_envelope
+    skip "eth/rlp gems not available" unless eth_and_rlp_available?
+
+    raw_tx, = Mpp::Methods::Tempo::Transaction.build_signed_transfer(
+      account: FakeAccount.new(ACCOUNT, "\x22" * 64 + "\x1c"),
+      chain_id: 42_431,
+      gas_limit: 1_000_000,
+      gas_price: 1,
+      nonce: 0,
+      nonce_key: (1 << 256) - 1,
+      currency: CURRENCY,
+      transfer_data: transfer_data,
+      valid_before: 9_999_999_999,
+      awaiting_fee_payer: true
+    )
+
+    decoded = decode_raw_tx(raw_tx, 0x78)
+
+    assert_equal 14, decoded.length
+    assert_equal "", decoded[10]
+    assert_equal ACCOUNT.downcase.delete_prefix("0x"), decoded[11].unpack1("H*")
+    assert_equal [], decoded[12]
+    assert_equal "\x22" * 64 + "\x01", decoded[13]
+  end
+
+  def test_fee_payer_signature_encodes_as_tuple_in_field_11
+    skip "rlp gem not available" unless rlp_available?
+
+    tx = Mpp::Methods::Tempo::Transaction::SignedTransaction.new(
+      chain_id: 42_431,
+      max_priority_fee_per_gas: 1,
+      max_fee_per_gas: 1,
+      gas_limit: 1_000_000,
+      calls: [Mpp::Methods::Tempo::Transaction::Call.new(to: CURRENCY, value: 0, data: transfer_data)],
+      access_list: [],
+      nonce_key: 0,
+      nonce: 0,
+      valid_before: nil,
+      valid_after: nil,
+      fee_token: CURRENCY,
+      sender_signature: "\x44" * 64 + "\x1b",
+      fee_payer_signature: "\x55" * 64 + "\x1c",
+      sender_address: ACCOUNT,
+      tempo_authorization_list: [],
+      key_authorization: nil
+    )
+
+    decoded = RLP.decode(tx.encoded_2718[1..])
+
+    assert_equal 14, decoded.length
+    assert_equal ["\x01", "\x55" * 32, "\x55" * 32], decoded[11]
+    assert_equal [], decoded[12]
+    assert_equal "\x44" * 64 + "\x00", decoded[13]
+  end
+
+  def test_charge_intent_cosigns_awaiting_fee_payer_envelope
+    skip "eth/rlp gems not available" unless eth_and_rlp_available?
+
+    payer = Mpp::Methods::Tempo::Account.from_key("0x#{"11" * 32}")
+    fee_payer = Mpp::Methods::Tempo::Account.from_key("0x#{"22" * 32}")
+    raw_tx, = Mpp::Methods::Tempo::Transaction.build_signed_transfer(
+      account: payer,
+      chain_id: 42_431,
+      gas_limit: 1_000_000,
+      gas_price: 1,
+      nonce: 0,
+      nonce_key: (1 << 256) - 1,
+      currency: CURRENCY,
+      transfer_data: transfer_data,
+      valid_before: Time.now.to_i + 60,
+      awaiting_fee_payer: true
+    )
+    intent = Mpp::Methods::Tempo::ChargeIntent.new
+    Mpp::Methods::Tempo.tempo(intents: {"charge" => intent}, fee_payer: fee_payer)
+
+    signed_raw = intent.send(:cosign_as_fee_payer, raw_tx, CURRENCY)
+    decoded = decode_raw_tx(signed_raw, 0x76)
+
+    assert_equal CURRENCY.downcase.delete_prefix("0x"), decoded[10].unpack1("H*")
+    assert_equal 3, decoded[11].length
+    assert_equal 65, decoded[13].bytesize
+  end
+
+  def test_charge_intent_cosigns_fee_payer_envelope_with_access_list
+    skip "eth/rlp gems not available" unless eth_and_rlp_available?
+
+    payer = Mpp::Methods::Tempo::Account.from_key("0x#{"11" * 32}")
+    fee_payer = Mpp::Methods::Tempo::Account.from_key("0x#{"22" * 32}")
+    access_list = [[pack_hex(CURRENCY), [pack_hex("0x#{"00" * 32}")]]]
+    tx = Mpp::Methods::Tempo::Transaction::SignedTransaction.new(
+      chain_id: 42_431,
+      max_priority_fee_per_gas: 1,
+      max_fee_per_gas: 1,
+      gas_limit: 1_000_000,
+      calls: [Mpp::Methods::Tempo::Transaction::Call.new(to: CURRENCY, value: 0, data: transfer_data)],
+      access_list: access_list,
+      nonce_key: (1 << 256) - 1,
+      nonce: 0,
+      valid_before: Time.now.to_i + 60,
+      valid_after: nil,
+      fee_token: nil,
+      sender_signature: nil,
+      fee_payer_signature: Mpp::Methods::Tempo::Transaction::EMPTY_SIGNATURE,
+      sender_address: payer.address,
+      tempo_authorization_list: [],
+      key_authorization: nil
+    )
+    sender_signature = payer.sign_hash(tx.signature_hash)
+    raw_tx = "0x#{Mpp::Methods::Tempo::FeePayer.encode(tx.with(sender_signature: sender_signature)).unpack1("H*")}"
+    intent = Mpp::Methods::Tempo::ChargeIntent.new
+    Mpp::Methods::Tempo.tempo(intents: {"charge" => intent}, fee_payer: fee_payer)
+
+    signed_raw = intent.send(:cosign_as_fee_payer, raw_tx, CURRENCY)
+    decoded = decode_raw_tx(signed_raw, 0x76)
+
+    assert_equal access_list, decoded[5]
+    assert_equal 3, decoded[11].length
+    assert_equal 65, decoded[13].bytesize
+  end
+
+  private
+
+  def transfer_data
+    to_padded = RECIPIENT.delete_prefix("0x").downcase.rjust(64, "0")
+    amount_padded = 1_000_000.to_s(16).rjust(64, "0")
+    "0xa9059cbb#{to_padded}#{amount_padded}"
+  end
+
+  def decode_raw_tx(raw_tx, prefix)
+    bytes = [raw_tx.delete_prefix("0x")].pack("H*")
+
+    assert_equal prefix, bytes.getbyte(0)
+    RLP.decode(bytes[1..])
+  end
+
+  def pack_hex(value)
+    [value.delete_prefix("0x")].pack("H*")
+  end
+
+  def eth_and_rlp_available?
+    require "eth"
+    rlp_available?
+  rescue LoadError
+    false
+  end
+
+  def rlp_available?
+    require "rlp"
+    true
+  rescue LoadError
+    false
   end
 end


### PR DESCRIPTION
## Summary

Add live Tempo devnet integration coverage for mpp-rb -- matching other MPP / Tempo SDKs

Fix Tempo transaction bugs found by the expanded coverage and review: 

* Sender signatures were encoded in the fee-payer field instead of the final signature envelope
* 0x78 fee-payer envelopes used invalid RLP encoding
* Sender and fee-token addresses were encoded as ASCII hex instead of bytes
* Fee-payer signing payloads used the wrong wire format
* Server-side fee-payer cosigning called a recovery API that is not available in the pinned eth dependency
* Cosigning rebuilt sender hashes without preserving access lists.