### PR TITLE
fix(stripe): pass idempotency key for charge intents

### DIFF
--- a/lib/mpp/methods/stripe/charge_intent.rb
+++ b/lib/mpp/methods/stripe/charge_intent.rb
@@ -60,7 +60,10 @@ module Mpp
 
           begin
             client = ::Stripe::StripeClient.new(@secret_key)
-            result = client.v1.payment_intents.create(params)
+            result = client.v1.payment_intents.create(
+              params,
+              {idempotency_key: stripe_idempotency_key(credential)}
+            )
           rescue => e
             raise Mpp::VerificationError, e.message
           end
@@ -83,6 +86,12 @@ module Mpp
           end
 
           Mpp::Receipt.success(pi_id, method: "stripe", external_id: external_id)
+        end
+
+        private
+
+        def stripe_idempotency_key(credential)
+          "mpp-stripe-charge-#{credential.challenge.id}"
         end
       end
     end

--- a/test/mpp/methods/stripe/test_charge_intent.rb
+++ b/test/mpp/methods/stripe/test_charge_intent.rb
@@ -75,7 +75,11 @@ class TestStripeChargeIntent < Minitest::Test
 
     mock_result = Struct.new(:id, :status).new("pi_abc123", "succeeded")
     mock_pi = Minitest::Mock.new
-    mock_pi.expect(:create, mock_result, [Hash])
+    mock_pi.expect(:create, mock_result) do |params, opts|
+      assert_equal 100, params[:amount]
+      assert_equal "usd", params[:currency]
+      assert_equal "mpp-stripe-charge-test-id", opts[:idempotency_key]
+    end
 
     mock_v1 = Struct.new(:payment_intents).new(mock_pi)
     mock_client = Struct.new(:v1).new(mock_v1)
@@ -123,7 +127,7 @@ class TestStripeChargeIntent < Minitest::Test
     mock_last_response = Struct.new(:headers).new(mock_headers)
     mock_result = Struct.new(:id, :status, :last_response).new("pi_abc123", "succeeded", mock_last_response)
     mock_pi = Minitest::Mock.new
-    mock_pi.expect(:create, mock_result, [Hash])
+    mock_pi.expect(:create, mock_result, [Hash, {idempotency_key: "mpp-stripe-charge-test-id"}])
 
     mock_v1 = Struct.new(:payment_intents).new(mock_pi)
     mock_client = Struct.new(:v1).new(mock_v1)
@@ -144,7 +148,7 @@ class TestStripeChargeIntent < Minitest::Test
 
     mock_result = Struct.new(:id, :status).new("pi_needs3ds", "requires_action")
     mock_pi = Minitest::Mock.new
-    mock_pi.expect(:create, mock_result, [Hash])
+    mock_pi.expect(:create, mock_result, [Hash, {idempotency_key: "mpp-stripe-charge-test-id"}])
 
     mock_v1 = Struct.new(:payment_intents).new(mock_pi)
     mock_client = Struct.new(:v1).new(mock_v1)


### PR DESCRIPTION
## Summary

Adds a Stripe idempotency key when the Ruby Stripe charge intent creates and confirms a PaymentIntent.

The key is derived from the MPP challenge ID, so retries of the same verified charge operation reuse the same logical Stripe request instead of risking a duplicate PaymentIntent creation. This matches Stripe's guidance to pass idempotency keys in request options for POST create/update calls.

## Changes

- Pass `{ idempotency_key: ... }` as the Stripe SDK request options when creating the PaymentIntent
- Derive the key from the MPP challenge ID: `mpp-stripe-charge-<challenge_id>`
- Update Stripe charge intent tests to assert the idempotency option is sent

## Verification

- `mise exec ruby@3.3 -- ruby -Ilib:test test/mpp/methods/stripe/test_charge_intent.rb`
- `mise exec ruby@3.3 -- standardrb lib/mpp/methods/stripe/charge_intent.rb test/mpp/methods/stripe/test_charge_intent.rb`
- `git diff --check`

Note: full `bundle install` could not complete in my local macOS environment because the `rbsecp256k1` native extension needs `aclocal` while building `eth`. The targeted Stripe test and StandardRB check both ran successfully after installing Ruby 3.3 with mise.
