### PR TITLE
fix(client): handle merged payment challenges

### DIFF
--- a/lib/mpp/challenge.rb
+++ b/lib/mpp/challenge.rb
@@ -58,18 +58,28 @@ module Mpp
       Mpp::Parsing.parse_www_authenticate(header)
     end
 
-    # Parse multiple Payment challenges from a merged WWW-Authenticate header.
-    # Handles RFC 9110 §11.6.1 comma-separated authentication schemes.
-    def self.from_www_authenticate_list(header)
+    # Split a merged WWW-Authenticate header value into the individual
+    # `Payment ...` challenge chunks it contains, handling RFC 9110 §11.6.1
+    # comma-separated authentication schemes. Returns the raw chunk strings so
+    # callers can parse each challenge independently; a malformed chunk then
+    # does not prevent the remaining chunks from being considered.
+    def self.www_authenticate_chunks(header)
       indices = []
       header.scan(/Payment\s+/i) { indices << T.must(Regexp.last_match).begin(0) }
       return [] if indices.empty?
 
       indices.each_with_index.map do |start_idx, i|
         end_idx = (i + 1 < indices.length) ? indices[i + 1] : header.length
-        chunk = T.must(header[start_idx...end_idx]).sub(/,\s*$/, "")
-        from_www_authenticate(chunk)
+        T.must(header[start_idx...end_idx]).sub(/,\s*$/, "")
       end
+    end
+
+    # Parse every Payment challenge from a merged WWW-Authenticate header.
+    # Raises Mpp::ParseError on the first malformed chunk; callers that need to
+    # tolerate a malformed challenge among valid ones should iterate
+    # `www_authenticate_chunks` and parse each chunk independently instead.
+    def self.from_www_authenticate_list(header)
+      www_authenticate_chunks(header).map { |chunk| from_www_authenticate(chunk) }
     end
 
     # Serialize to a WWW-Authenticate header value.

--- a/lib/mpp/client/transport.rb
+++ b/lib/mpp/client/transport.rb
@@ -205,18 +205,22 @@ module Mpp
       sig { params(www_auth_headers: T.untyped, input: T.untyped, response: T.untyped).returns(T::Array[T.untyped]) }
       def find_matching_challenge(www_auth_headers, input: nil, response: nil)
         www_auth_headers.each do |header|
-          Mpp::Challenge.from_www_authenticate_list(header).each do |parsed|
+          Mpp::Challenge.www_authenticate_chunks(header).each do |chunk|
+            parsed = Mpp::Challenge.from_www_authenticate(chunk)
             return [parsed, @methods[parsed.method]] if @methods.key?(parsed.method)
+          rescue Mpp::ParseError => e
+            # Skip a malformed challenge but keep scanning the rest: a bad chunk
+            # earlier in a merged value must not hide a supported challenge that
+            # follows it.
+            if @events.has_handlers?(Mpp::Events::PAYMENT_FAILED)
+              @events.emit(Mpp::Events::PAYMENT_FAILED, {
+                error: e,
+                input: input,
+                response: response
+              })
+            end
+            next
           end
-        rescue Mpp::ParseError => e
-          if @events.has_handlers?(Mpp::Events::PAYMENT_FAILED)
-            @events.emit(Mpp::Events::PAYMENT_FAILED, {
-              error: e,
-              input: input,
-              response: response
-            })
-          end
-          next
         end
         [nil, nil]
       end

--- a/lib/mpp/client/transport.rb
+++ b/lib/mpp/client/transport.rb
@@ -205,21 +205,18 @@ module Mpp
       sig { params(www_auth_headers: T.untyped, input: T.untyped, response: T.untyped).returns(T::Array[T.untyped]) }
       def find_matching_challenge(www_auth_headers, input: nil, response: nil)
         www_auth_headers.each do |header|
-          next unless header.downcase.start_with?("payment ")
-
-          begin
-            parsed = Mpp::Challenge.from_www_authenticate(header)
+          Mpp::Challenge.from_www_authenticate_list(header).each do |parsed|
             return [parsed, @methods[parsed.method]] if @methods.key?(parsed.method)
-          rescue Mpp::ParseError => e
-            if @events.has_handlers?(Mpp::Events::PAYMENT_FAILED)
-              @events.emit(Mpp::Events::PAYMENT_FAILED, {
-                error: e,
-                input: input,
-                response: response
-              })
-            end
-            next
           end
+        rescue Mpp::ParseError => e
+          if @events.has_handlers?(Mpp::Events::PAYMENT_FAILED)
+            @events.emit(Mpp::Events::PAYMENT_FAILED, {
+              error: e,
+              input: input,
+              response: response
+            })
+          end
+          next
         end
         [nil, nil]
       end

--- a/test/mpp/test_client.rb
+++ b/test/mpp/test_client.rb
@@ -347,6 +347,36 @@ class TestClientTransport < Minitest::Test
     assert_equal "200", response.code
     assert_equal "paid", response.body
   end
+
+  def test_handles_merged_challenges_with_a_malformed_leading_chunk
+    seen = []
+    @transport.on_payment_failed { |payload| seen << payload[:error] }
+
+    supported = Mpp::Challenge.create(
+      secret_key: "test-secret",
+      realm: "api.example.com",
+      method: "tempo",
+      intent: "charge",
+      request: {"amount" => "1000000"},
+      expires: Mpp::Expires.minutes(5)
+    )
+    # A malformed Payment challenge precedes a valid supported one in the same
+    # merged WWW-Authenticate value. The bad chunk must not hide the good one.
+    www_auth = "Payment invalidbase64!!!, #{supported.to_www_authenticate("api.example.com")}"
+
+    stub_request(:get, "https://api.example.com/resource")
+      .to_return(status: 402, headers: {"WWW-Authenticate" => www_auth})
+      .then
+      .to_return(status: 200, body: "paid")
+
+    response = @transport.get("https://api.example.com/resource")
+
+    assert_equal "200", response.code
+    assert_equal "paid", response.body
+    # The malformed leading chunk is still reported, it just no longer hides
+    # the supported challenge that follows it.
+    assert(seen.any? { |e| e.is_a?(Mpp::ParseError) })
+  end
 end
 
 class TestClientConvenience < Minitest::Test

--- a/test/mpp/test_client.rb
+++ b/test/mpp/test_client.rb
@@ -317,6 +317,36 @@ class TestClientTransport < Minitest::Test
     assert_equal "403", response.code
     assert_equal [[challenge.id, "403", "Payment verification failed: retry returned HTTP 403."]], seen
   end
+
+  def test_handles_merged_payment_challenges
+    unsupported = Mpp::Challenge.create(
+      secret_key: "test-secret",
+      realm: "api.example.com",
+      method: "other",
+      intent: "charge",
+      request: {"amount" => "1000000"},
+      expires: Mpp::Expires.minutes(5)
+    )
+    supported = Mpp::Challenge.create(
+      secret_key: "test-secret",
+      realm: "api.example.com",
+      method: "tempo",
+      intent: "charge",
+      request: {"amount" => "1000000"},
+      expires: Mpp::Expires.minutes(5)
+    )
+    www_auth = "#{unsupported.to_www_authenticate("api.example.com")}, #{supported.to_www_authenticate("api.example.com")}"
+
+    stub_request(:get, "https://api.example.com/resource")
+      .to_return(status: 402, headers: {"WWW-Authenticate" => www_auth})
+      .then
+      .to_return(status: 200, body: "paid")
+
+    response = @transport.get("https://api.example.com/resource")
+
+    assert_equal "200", response.code
+    assert_equal "paid", response.body
+  end
 end
 
 class TestClientConvenience < Minitest::Test


### PR DESCRIPTION
## Summary

- Parse merged `WWW-Authenticate` headers with `Challenge.from_www_authenticate_list` in the client transport.
- Keep skipping malformed or unsupported challenges, but continue looking for a supported payment method in the same header value.
- Add a client transport test where an unsupported challenge appears before a supported one in a merged header.

## Why

- The parser already supports RFC-style comma-separated `Payment` challenges, but the client transport only tried to parse each header value as one challenge.
- Servers or proxies can combine multiple `WWW-Authenticate` values into one header, so the client should still find a supported MPP method.

## Verification

- `mise exec ruby@3.3.11 -- ruby -Ilib -Itest test/mpp/test_client.rb`
- `mise exec ruby@3.3.11 -- ruby -Ilib -Itest test/mpp/test_parsing.rb`
- `mise exec ruby@3.3.11 -- ruby -c lib/mpp/client/transport.rb`
- `mise exec ruby@3.3.11 -- ruby -c test/mpp/test_client.rb`
- `git diff --check`

## Notes

- I also tried the Bundler path with `mise exec ruby@3.3.11 -- bundle exec rake test test/mpp/test_client.rb`; local dependency installation is blocked by native `rbsecp256k1` build prerequisites (`aclocal`/automake) on this machine, so I ran the focused tests directly with the repo `lib` and `test` load paths.
