### PR TITLE
fix(mcp): preserve receipt method

### DIFF
--- a/lib/mpp/extensions/mcp/types.rb
+++ b/lib/mpp/extensions/mcp/types.rb
@@ -182,7 +182,8 @@ module Mpp
           Mpp::Receipt.new(
             status: status,
             timestamp: Time.iso8601(timestamp.gsub("Z", "+00:00")),
-            reference: reference || ""
+            reference: reference || "",
+            method: method
           )
         end
 

--- a/test/mpp/extensions/mcp/test_types.rb
+++ b/test/mpp/extensions/mcp/test_types.rb
@@ -148,6 +148,22 @@ class TestMCPTypes < Minitest::Test
     assert meta.key?("org.paymentauth/receipt")
   end
 
+  def test_mcp_receipt_to_core_preserves_method
+    receipt = Mpp::Extensions::MCP::MCPReceipt.new(
+      status: "success",
+      challenge_id: "ch_abc",
+      method: "stripe",
+      timestamp: "2026-01-15T12:00:30Z",
+      reference: "pi_123"
+    )
+
+    core_receipt = receipt.to_core
+
+    assert_instance_of Mpp::Receipt, core_receipt
+    assert_equal "stripe", core_receipt.method
+    assert_equal "pi_123", core_receipt.reference
+  end
+
   def test_mcp_receipt_from_core
     core_receipt = Mpp::Receipt.new(
       status: "success",


### PR DESCRIPTION
## Summary

- Preserve `MCPReceipt#method` when converting an MCP receipt back to a core `Mpp::Receipt`.
- Add a regression test covering non-default payment method provenance during `to_core`.

## Why

- MCP receipts carry the payment method/rail provenance, but `to_core` previously constructed `Mpp::Receipt` without passing `method`, which defaulted the core receipt back to `""`.
- Keeping this field intact helps downstream receipt/evidence handling distinguish rails such as Stripe, Tempo, or other MPP methods.

## Verification

- `mise exec ruby@3.3.11 -- ruby -Ilib -Itest test/mpp/extensions/mcp/test_types.rb`
- `mise exec ruby@3.3.11 -- ruby -c lib/mpp/extensions/mcp/types.rb`
- `mise exec ruby@3.3.11 -- ruby -c test/mpp/extensions/mcp/test_types.rb`
- `git diff --check`
