### PR TITLE
fix(server): vary paid middleware responses

### DIFF
--- a/lib/mpp/server/decorator.rb
+++ b/lib/mpp/server/decorator.rb
@@ -20,6 +20,7 @@ module Mpp
           "Cache-Control" => "no-store",
           "Content-Type" => "application/problem+json"
         }
+        Mpp::Server::Middleware.mark_authorization_bound_response(headers)
         {
           "_mpp_challenge" => true,
           "status" => 402,

--- a/lib/mpp/server/middleware.rb
+++ b/lib/mpp/server/middleware.rb
@@ -43,8 +43,24 @@ module Mpp
 
         _credential, receipt = result
         headers["Payment-Receipt"] = receipt.to_payment_receipt
+        self.class.mark_authorization_bound_response(headers)
 
         [status, headers, body]
+      end
+
+      sig { params(headers: T::Hash[T.untyped, T.untyped]).void }
+      def self.mark_authorization_bound_response(headers)
+        headers["Cache-Control"] = "no-store"
+
+        vary_values = headers["Vary"].to_s.split(",").map do |value|
+          value.strip.downcase
+        end
+        return if vary_values.include?("*") || vary_values.include?("authorization")
+
+        headers["Vary"] = [headers["Vary"], "Authorization"]
+          .compact
+          .reject(&:empty?)
+          .join(", ")
       end
     end
   end

--- a/test/mpp/test_middleware.rb
+++ b/test/mpp/test_middleware.rb
@@ -31,6 +31,8 @@ class TestMiddleware < Minitest::Test
     assert_equal 402, status
     assert headers.key?("WWW-Authenticate")
     assert_equal "application/problem+json", headers["Content-Type"]
+    assert_equal "no-store", headers["Cache-Control"]
+    assert_vary_authorization headers
   end
 
   def test_attaches_receipt_on_successful_payment
@@ -58,6 +60,8 @@ class TestMiddleware < Minitest::Test
 
     assert_equal 200, status
     assert headers.key?("Payment-Receipt")
+    assert_equal "no-store", headers["Cache-Control"]
+    assert_vary_authorization headers
     assert_equal ["OK"], body
   end
 
@@ -68,6 +72,13 @@ class TestMiddleware < Minitest::Test
       "REQUEST_METHOD" => "GET",
       "PATH_INFO" => "/resource"
     }
+  end
+
+  def assert_vary_authorization(headers)
+    vary_fields = headers.fetch("Vary", "").split(",").map do |field|
+      field.strip.downcase
+    end
+    assert_includes vary_fields, "authorization"
   end
 
   def mock_handler


### PR DESCRIPTION
## Summary
- add `Vary: Authorization` to Rack 402 payment challenges
- mark successful paid middleware responses `Cache-Control: no-store`
- keep `Payment-Receipt` responses authorization-bound to avoid shared-cache reuse

## Verification
- `mise exec ruby@3.3 -- ruby -Ilib -Itest test/mpp/test_middleware.rb`
- `mise exec ruby@3.3 -- ruby -c lib/mpp/server/middleware.rb`
- `mise exec ruby@3.3 -- ruby -c lib/mpp/server/decorator.rb`
- `mise exec ruby@3.3 -- ruby -c test/mpp/test_middleware.rb`
- `git diff --check`

Note: `bundle install` could not complete locally because the native `rbsecp256k1` build needs `aclocal`; this patch does not change dependencies and the focused middleware test passes without that native gem.