### PR TITLE
fix(receipt): preserve success extra metadata

### DIFF
--- a/lib/mpp/receipt.rb
+++ b/lib/mpp/receipt.rb
@@ -18,13 +18,14 @@ module Mpp
     end
 
     # Create a success receipt with current timestamp.
-    def self.success(reference, timestamp: nil, method: "tempo", external_id: nil)
+    def self.success(reference, timestamp: nil, method: "tempo", external_id: nil, extra: nil)
       new(
         status: "success",
         timestamp: timestamp || Time.now.utc,
         reference: reference,
         method: method,
-        external_id: external_id
+        external_id: external_id,
+        extra: extra
       )
     end
   end

--- a/sorbet/rbi/shims/receipt.rbi
+++ b/sorbet/rbi/shims/receipt.rbi
@@ -43,9 +43,10 @@ module Mpp
         reference: String,
         timestamp: T.nilable(Time),
         method: String,
-        external_id: T.nilable(String)
+        external_id: T.nilable(String),
+        extra: T.nilable(T::Hash[String, T.untyped])
       ).returns(Receipt)
     end
-    def self.success(reference, timestamp: nil, method: "tempo", external_id: nil); end
+    def self.success(reference, timestamp: nil, method: "tempo", external_id: nil, extra: nil); end
   end
 end

--- a/test/mpp/test_parsing.rb
+++ b/test/mpp/test_parsing.rb
@@ -202,6 +202,15 @@ class TestParsing < Minitest::Test
     assert_instance_of Time, receipt.timestamp
   end
 
+  def test_receipt_success_factory_preserves_extra
+    receipt = Mpp::Receipt.success(
+      "0xdeadbeef",
+      extra: {"trace_id" => "trace-123"}
+    )
+
+    assert_equal({"trace_id" => "trace-123"}, receipt.extra)
+  end
+
   def test_parse_payment_receipt_rejects_invalid_method_ids
     invalid_payment_method_ids.each do |payment_method|
       payload = {


### PR DESCRIPTION
## Summary
- add an `extra:` keyword to `Mpp::Receipt.success`
- pass the extra receipt metadata through to the underlying `Receipt`
- update the Sorbet shim and add a regression test

## Why
`Mpp::Receipt` already models `extra`, and receipt parsing/formatting preserves it in the `Payment-Receipt` header. The `Receipt.success` convenience constructor dropped that metadata, which made it harder for successful payment receipts to carry trace IDs or other opaque settlement evidence without manually constructing the receipt.

## Verification
- `mise exec ruby@3.4 -- ruby -Ilib -Itest test/mpp/test_parsing.rb -n test_receipt_success_factory_preserves_extra` passed after the fix
- `mise exec ruby@3.4 -- bundle exec ruby -Itest test/mpp/test_parsing.rb -n test_receipt_success_factory_preserves_extra`
- `mise exec ruby@3.4 -- bundle exec ruby -Itest test/mpp/test_parsing.rb`
- `mise exec ruby@3.4 -- bundle exec rake test`
- `mise exec ruby@3.4 -- bundle exec standardrb`
- `mise exec ruby@3.4 -- bundle exec srb tc`