### PR TITLE
fix(parsing): ignore quoted payment schemes

### DIFF
--- a/lib/mpp/challenge.rb
+++ b/lib/mpp/challenge.rb
@@ -61,15 +61,79 @@ module Mpp
     # Parse multiple Payment challenges from a merged WWW-Authenticate header.
     # Handles RFC 9110 §11.6.1 comma-separated authentication schemes.
     def self.from_www_authenticate_list(header)
-      indices = []
-      header.scan(/Payment\s+/i) { indices << T.must(Regexp.last_match).begin(0) }
+      indices = payment_scheme_indices(header)
       return [] if indices.empty?
 
       indices.each_with_index.map do |start_idx, i|
-        end_idx = (i + 1 < indices.length) ? indices[i + 1] : header.length
+        end_idx = if i + 1 < indices.length
+          indices[i + 1]
+        else
+          next_auth_scheme_index(header, start_idx + "Payment".length) || header.length
+        end
         chunk = T.must(header[start_idx...end_idx]).sub(/,\s*$/, "")
         from_www_authenticate(chunk)
       end
+    end
+
+    def self.payment_scheme_indices(header)
+      indices = []
+      each_auth_scheme_index(header) do |index, scheme|
+        indices << index if scheme.casecmp("Payment").zero?
+      end
+      indices
+    end
+
+    def self.next_auth_scheme_index(header, offset)
+      each_auth_scheme_index(header, offset) do |index, _scheme|
+        return index
+      end
+      nil
+    end
+
+    def self.each_auth_scheme_index(header, offset = 0)
+      in_quote = false
+      escaped = false
+      i = offset
+
+      while i < header.length
+        char = T.must(header[i])
+
+        if in_quote
+          if escaped
+            escaped = false
+          elsif char == "\\"
+            escaped = true
+          elsif char == "\""
+            in_quote = false
+          end
+          i += 1
+          next
+        end
+
+        if char == "\""
+          in_quote = true
+          i += 1
+          next
+        end
+
+        if scheme_boundary?(header, i)
+          match = T.must(header[i..]).match(/\A([A-Za-z][A-Za-z0-9._~+\/-]*)\s+/)
+          if match
+            yield i, T.must(match[1])
+            i += T.must(match[0]).length
+            next
+          end
+        end
+
+        i += 1
+      end
+    end
+
+    def self.scheme_boundary?(header, index)
+      return true if index == 0
+
+      previous = T.must(header[0...index]).rstrip
+      previous.end_with?(",")
     end
 
     # Serialize to a WWW-Authenticate header value.

--- a/lib/mpp/challenge.rb
+++ b/lib/mpp/challenge.rb
@@ -61,15 +61,11 @@ module Mpp
     # Parse multiple Payment challenges from a merged WWW-Authenticate header.
     # Handles RFC 9110 §11.6.1 comma-separated authentication schemes.
     def self.from_www_authenticate_list(header)
-      indices = payment_scheme_indices(header)
-      return [] if indices.empty?
-
-      indices.each_with_index.map do |start_idx, i|
-        end_idx = if i + 1 < indices.length
-          indices[i + 1]
-        else
-          next_auth_scheme_index(header, start_idx + "Payment".length) || header.length
-        end
+      payment_scheme_indices(header).map do |start_idx|
+        # End each chunk at the next scheme boundary of any kind, so an
+        # interleaved non-Payment scheme (e.g. "Payment ..., Bearer ...,
+        # Payment ...") is not folded into the preceding Payment challenge.
+        end_idx = next_auth_scheme_index(header, start_idx + "Payment".length) || header.length
         chunk = T.must(header[start_idx...end_idx]).sub(/,\s*$/, "")
         from_www_authenticate(chunk)
       end

--- a/lib/mpp/challenge.rb
+++ b/lib/mpp/challenge.rb
@@ -118,7 +118,9 @@ module Mpp
 
         if scheme_boundary?(header, i)
           match = T.must(header[i..]).match(/\A([A-Za-z][A-Za-z0-9._~+\/-]*)\s+/)
-          if match
+          # An auth-param permits OWS around "=" (key\s*=\s*value), so a token
+          # followed by whitespace then "=" is a parameter, not a new scheme.
+          if match && header[i + T.must(match[0]).length] != "="
             yield i, T.must(match[1])
             i += T.must(match[0]).length
             next

--- a/lib/mpp/challenge.rb
+++ b/lib/mpp/challenge.rb
@@ -91,8 +91,8 @@ module Mpp
     end
 
     def self.each_auth_scheme_index(header, offset = 0)
-      in_quote = false
-      escaped = false
+      in_quote = T.let(false, T::Boolean)
+      escaped = T.let(false, T::Boolean)
       i = offset
 
       while i < header.length

--- a/lib/mpp/challenge.rb
+++ b/lib/mpp/challenge.rb
@@ -130,9 +130,12 @@ module Mpp
     end
 
     def self.scheme_boundary?(header, index)
-      return true if index == 0
-
       previous = T.must(header[0...index]).rstrip
+      # Start of the header, including the case where only optional whitespace
+      # (RFC 9110 OWS) precedes the first scheme; otherwise a scheme is a
+      # boundary only immediately after a comma separating two schemes.
+      return true if previous.empty?
+
       previous.end_with?(",")
     end
 

--- a/test/mpp/test_parsing.rb
+++ b/test/mpp/test_parsing.rb
@@ -241,6 +241,45 @@ class TestParsing < Minitest::Test
     assert_equal "other", result[1].method
   end
 
+  def test_from_www_authenticate_list_ignores_payment_scheme_inside_quotes
+    c1 = Mpp::Challenge.create(
+      secret_key: "s1",
+      realm: "api, Payment realm",
+      method: "tempo",
+      intent: "charge",
+      request: {"amount" => "100"}
+    )
+    c2 = Mpp::Challenge.create(
+      secret_key: "s2",
+      realm: "api.example.com",
+      method: "stripe",
+      intent: "charge",
+      request: {"amount" => "200"}
+    )
+    header = "#{c1.to_www_authenticate("api, Payment realm")}, #{c2.to_www_authenticate("api.example.com")}"
+    result = Mpp::Challenge.from_www_authenticate_list(header)
+
+    assert_equal 2, result.length
+    assert_equal "api, Payment realm", result[0].realm
+    assert_equal "tempo", result[0].method
+    assert_equal "stripe", result[1].method
+  end
+
+  def test_from_www_authenticate_list_stops_before_next_non_payment_scheme
+    challenge = Mpp::Challenge.create(
+      secret_key: "test-secret",
+      realm: "api.example.com",
+      method: "tempo",
+      intent: "charge",
+      request: {"amount" => "1000000"}
+    )
+    header = "#{challenge.to_www_authenticate("api.example.com")}, Bearer realm=\"fallback\""
+    result = Mpp::Challenge.from_www_authenticate_list(header)
+
+    assert_equal 1, result.length
+    assert_equal challenge.id, result[0].id
+  end
+
   def test_from_www_authenticate_list_empty
     assert_equal [], Mpp::Challenge.from_www_authenticate_list("Bearer token123")
     assert_equal [], Mpp::Challenge.from_www_authenticate_list("")

--- a/test/mpp/test_parsing.rb
+++ b/test/mpp/test_parsing.rb
@@ -218,6 +218,24 @@ class TestParsing < Minitest::Test
     assert_equal challenge.id, result[0].id
   end
 
+  def test_from_www_authenticate_list_leading_whitespace
+    challenge = Mpp::Challenge.create(
+      secret_key: "test-secret",
+      realm: "api.example.com",
+      method: "tempo",
+      intent: "charge",
+      request: {"amount" => "1000000"}
+    )
+    # A header carrying leading optional whitespace (RFC 9110 OWS) must still
+    # surface the Payment challenge; the first scheme is a boundary even when
+    # whitespace precedes it.
+    header = "   #{challenge.to_www_authenticate("api.example.com")}"
+    result = Mpp::Challenge.from_www_authenticate_list(header)
+
+    assert_equal 1, result.length
+    assert_equal challenge.id, result[0].id
+  end
+
   def test_from_www_authenticate_list_multiple
     c1 = Mpp::Challenge.create(
       secret_key: "s1",

--- a/test/mpp/test_parsing.rb
+++ b/test/mpp/test_parsing.rb
@@ -298,6 +298,16 @@ class TestParsing < Minitest::Test
     assert_equal challenge.id, result[0].id
   end
 
+  def test_from_www_authenticate_list_allows_whitespace_around_param_equals
+    header = 'Payment id="ch", realm = "api", method="tempo", intent="charge", request="e30"'
+    result = Mpp::Challenge.from_www_authenticate_list(header)
+
+    # OWS around "=" (key\s*=\s*value) must not be mistaken for a new scheme
+    # after a comma, so the challenge stays whole instead of truncating at realm.
+    assert_equal 1, result.length
+    assert_equal "tempo", result[0].method
+  end
+
   def test_from_www_authenticate_list_empty
     assert_equal [], Mpp::Challenge.from_www_authenticate_list("Bearer token123")
     assert_equal [], Mpp::Challenge.from_www_authenticate_list("")

--- a/test/mpp/test_parsing.rb
+++ b/test/mpp/test_parsing.rb
@@ -308,6 +308,26 @@ class TestParsing < Minitest::Test
     assert_equal "tempo", result[0].method
   end
 
+  def test_from_www_authenticate_list_ignores_interleaved_non_payment_scheme
+    first = Mpp::Challenge.create(secret_key: "s", realm: "api.example.com", method: "tempo",
+      intent: "charge", request: {"amount" => "1"})
+    second = Mpp::Challenge.create(secret_key: "s", realm: "api.example.com", method: "tempo",
+      intent: "charge", request: {"amount" => "2"})
+    header = [
+      first.to_www_authenticate("api.example.com"),
+      'Bearer realm="fallback"',
+      second.to_www_authenticate("api.example.com")
+    ].join(", ")
+
+    result = Mpp::Challenge.from_www_authenticate_list(header)
+
+    # The interleaved Bearer scheme must terminate the first chunk rather than
+    # folding into it (which would surface as a duplicate realm parse error).
+    assert_equal 2, result.length
+    assert_equal first.id, result[0].id
+    assert_equal second.id, result[1].id
+  end
+
   def test_from_www_authenticate_list_empty
     assert_equal [], Mpp::Challenge.from_www_authenticate_list("Bearer token123")
     assert_equal [], Mpp::Challenge.from_www_authenticate_list("")


### PR DESCRIPTION
## Summary

Parse merged `WWW-Authenticate` headers by scanning for auth schemes only at real scheme boundaries, so `Payment` is not treated as a scheme when it appears inside a quoted challenge parameter.

- Scan with a quote-aware state machine (handles `\"` escapes), so a quoted value such as `realm="needs Payment here"` is never mistaken for a new scheme.
- A scheme boundary is start-of-header (including leading optional whitespace, RFC 9110 OWS) or immediately after a comma, so the final Payment challenge stops before a following non-Payment scheme such as `Bearer`.
- Regression coverage for quoted Payment text, trailing non-Payment schemes, and leading-whitespace headers.

## Why

Proxies and servers can merge multiple auth schemes into one `WWW-Authenticate` header. Challenge selection must key off real scheme boundaries, not text inside quoted parameters, or a client could pick the wrong challenge (or none).

## Verification

`srb tc`, `bundle exec rake test`, and `standardrb` all clean.

---

### Reviewer note (Claude Fable 5)

Claude Fable 5 reviewed this PR. The surface to read is `each_auth_scheme_index` / `scheme_boundary?` in `lib/mpp/challenge.rb`. I checked the adversarial cases a merged header can throw at it: `Payment` inside a quoted value, `XPayment` mid-token, escaped quotes, commas inside quoted values, unterminated quotes (no infinite loop or index panic), and a trailing `Bearer` after a comma. All behave correctly and none let a crafted header subvert challenge selection. One real edge it now also handles: a header with leading whitespace previously dropped the Payment challenge because `scheme_boundary?` only accepted index 0 or a position right after a comma, so a whitespace-only prefix is now treated as the start-of-header boundary. The Sorbet `T.let(false, T::Boolean)` on the loop flags is a static annotation only, no runtime behavior change.
