### PR TITLE
fix(parsing): reject malformed auth params

### DIFF
--- a/lib/mpp/parsing.rb
+++ b/lib/mpp/parsing.rb
@@ -57,12 +57,29 @@ module Mpp
     sig { params(params_str: T.untyped).returns(T::Hash[T.untyped, T.untyped]) }
     def parse_auth_params(params_str)
       params = {}
+      pos = 0
+      first = T.let(true, T::Boolean)
+
       params_str.scan(AUTH_PARAM_RE) do |key, quoted_val, token_val|
+        match = T.must(Regexp.last_match)
+        separator = params_str[pos...match.begin(0)]
+        if first
+          Kernel.raise Mpp::ParseError, "Malformed authentication parameters" unless separator.strip.empty?
+        else
+          Kernel.raise Mpp::ParseError, "Malformed authentication parameters" unless separator.match?(/\A\s*,\s*\z/)
+        end
+
         Kernel.raise Mpp::ParseError, "Duplicate parameter: #{key}" if params.key?(key)
 
         value = quoted_val.nil? ? token_val : unescape_quoted(quoted_val)
         params[key] = value
+        pos = match.end(0)
+        first = false
       end
+
+      tail = params_str[pos..]
+      Kernel.raise Mpp::ParseError, "Malformed authentication parameters" unless tail.strip.empty?
+
       params
     end
 

--- a/test/mpp/test_parsing.rb
+++ b/test/mpp/test_parsing.rb
@@ -77,6 +77,23 @@ class TestParsing < Minitest::Test
     end
   end
 
+  def test_parse_www_authenticate_rejects_malformed_auth_params
+    challenge = Mpp::Challenge.create(
+      secret_key: "test-secret",
+      realm: "api.example.com",
+      method: "tempo",
+      intent: "charge",
+      request: {"amount" => "1000000"}
+    )
+    header = challenge.to_www_authenticate("api.example.com")
+
+    missing_separator = header.sub(", realm=", " realm=")
+    trailing_junk = "#{header} not-a-param"
+
+    assert_raises(Mpp::ParseError) { Mpp::Challenge.from_www_authenticate(missing_separator) }
+    assert_raises(Mpp::ParseError) { Mpp::Challenge.from_www_authenticate(trailing_junk) }
+  end
+
   def test_credential_roundtrip
     echo = Mpp::ChallengeEcho.new(
       id: "test-id",


### PR DESCRIPTION
## Summary

Reject malformed `WWW-Authenticate: Payment` auth-param lists instead of silently accepting partial regex matches.

This catches cases where required params are present but the header is still malformed, for example:

- missing comma separators between auth params
- trailing non-param junk after an otherwise valid challenge

## Why

The parser previously used `scan`, so malformed text between or after matched params could be ignored. For payment challenges, accepting a partially parsed header can hide producer bugs and make interop failures harder to diagnose.

## Verification

- `mise exec ruby@3.3 -- bundle exec ruby -Itest test/mpp/test_parsing.rb`
- `mise exec ruby@3.3 -- bundle exec rake test`
- `mise exec ruby@3.3 -- bundle exec standardrb lib/mpp/parsing.rb test/mpp/test_parsing.rb`
- `git diff --check`
