### PR TITLE
fix: reject invalid payment method ids

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,38 @@
+name: Conformance
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+      - labeled
+      - unlabeled
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  conformance-policy:
+    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance-policy.yml@main
+    with:
+      protocol-paths: |
+        lib/**
+        Gemfile
+        Gemfile.lock
+        mpp-rb.gemspec
+
+  conformance:
+    needs: conformance-policy
+    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance.yml@main
+    with:
+      adapter: ruby
+      conformance-ref: ${{ needs.conformance-policy.outputs.conformance_ref }}

--- a/lib/mpp/parsing.rb
+++ b/lib/mpp/parsing.rb
@@ -13,6 +13,7 @@ module Mpp
 
     # RFC 9110 auth-param regex: key="value" or key=token
     AUTH_PARAM_RE = /([a-zA-Z_][\w-]*+)\s*=\s*(?:"((?:[^"\\]|\\.)*)"|([^\s,]++))/
+    PAYMENT_METHOD_ID_RE = /\A[a-z]+\z/
 
     module_function
 
@@ -65,6 +66,11 @@ module Mpp
       params
     end
 
+    sig { params(method: T.untyped).void }
+    def validate_payment_method_id(method)
+      Kernel.raise Mpp::ParseError, "Invalid payment method ID" unless method.is_a?(String) && PAYMENT_METHOD_ID_RE.match?(method)
+    end
+
     # Parse a WWW-Authenticate header into a Challenge.
     sig { params(header: T.untyped).returns(Mpp::Challenge) }
     def parse_www_authenticate(header)
@@ -82,6 +88,7 @@ module Mpp
 
       method = params["method"]
       Kernel.raise Mpp::ParseError, "Missing 'method' field" unless method && !method.empty?
+      validate_payment_method_id(method)
 
       intent = params["intent"]
       Kernel.raise Mpp::ParseError, "Missing 'intent' field" unless intent && !intent.empty?
@@ -148,10 +155,13 @@ module Mpp
       Kernel.raise Mpp::ParseError, "Credential challenge must be an object" unless challenge_data.is_a?(Hash)
       Kernel.raise Mpp::ParseError, "Credential challenge missing required field: id" unless challenge_data.key?("id")
 
+      method = (challenge_data["method"] || "").to_s
+      validate_payment_method_id(method)
+
       echo = Mpp::ChallengeEcho.new(
         id: challenge_data["id"].to_s,
         realm: (challenge_data["realm"] || "").to_s,
-        method: (challenge_data["method"] || "").to_s,
+        method: method,
         intent: (challenge_data["intent"] || "").to_s,
         request: (challenge_data["request"] || "").to_s,
         expires: challenge_data["expires"]&.to_s,
@@ -213,6 +223,8 @@ module Mpp
       Kernel.raise Mpp::ParseError, "Invalid receipt status" unless status == "success"
 
       timestamp = parse_timestamp(data["timestamp"].to_s)
+      method = data["method"].to_s
+      validate_payment_method_id(method)
 
       extra = data["extra"]
       extra = nil unless extra.is_a?(Hash)
@@ -221,7 +233,7 @@ module Mpp
         status: status,
         timestamp: timestamp,
         reference: data["reference"].to_s,
-        method: (data["method"] || "").to_s,
+        method: method,
         external_id: data["externalId"]&.to_s,
         extra: extra
       )

--- a/lib/mpp/parsing.rb
+++ b/lib/mpp/parsing.rb
@@ -155,7 +155,7 @@ module Mpp
       Kernel.raise Mpp::ParseError, "Credential challenge must be an object" unless challenge_data.is_a?(Hash)
       Kernel.raise Mpp::ParseError, "Credential challenge missing required field: id" unless challenge_data.key?("id")
 
-      method = (challenge_data["method"] || "").to_s
+      method = challenge_data["method"]
       validate_payment_method_id(method)
 
       echo = Mpp::ChallengeEcho.new(
@@ -223,7 +223,7 @@ module Mpp
       Kernel.raise Mpp::ParseError, "Invalid receipt status" unless status == "success"
 
       timestamp = parse_timestamp(data["timestamp"].to_s)
-      method = data["method"].to_s
+      method = data["method"]
       validate_payment_method_id(method)
 
       extra = data["extra"]

--- a/test/mpp/test_parsing.rb
+++ b/test/mpp/test_parsing.rb
@@ -67,6 +67,16 @@ class TestParsing < Minitest::Test
     assert_raises(Mpp::ParseError) { Mpp::Challenge.from_www_authenticate('Payment id="abc"') }
   end
 
+  def test_parse_www_authenticate_rejects_invalid_method_ids
+    request_b64 = Mpp::Parsing.b64_encode({"amount" => "1000000"})
+
+    invalid_payment_method_ids.each do |payment_method|
+      header = %(Payment id="abc", realm="api.example.com", method="#{payment_method}", intent="charge", request="#{request_b64}")
+
+      assert_raises(Mpp::ParseError) { Mpp::Challenge.from_www_authenticate(header) }
+    end
+  end
+
   def test_credential_roundtrip
     echo = Mpp::ChallengeEcho.new(
       id: "test-id",
@@ -115,6 +125,24 @@ class TestParsing < Minitest::Test
     assert_raises(Mpp::ParseError) { Mpp::Credential.from_authorization("Bearer token123") }
   end
 
+  def test_parse_authorization_rejects_invalid_challenge_method_ids
+    invalid_payment_method_ids.each do |payment_method|
+      payload = {
+        "challenge" => {
+          "id" => "test-id",
+          "realm" => "api.example.com",
+          "method" => payment_method,
+          "intent" => "charge",
+          "request" => "e30"
+        },
+        "payload" => {"type" => "hash", "hash" => "0xabc"}
+      }
+      header = "Payment #{Mpp::Parsing.b64_encode(payload)}"
+
+      assert_raises(Mpp::ParseError) { Mpp::Credential.from_authorization(header) }
+    end
+  end
+
   def test_receipt_roundtrip
     receipt = Mpp::Receipt.new(
       status: "success",
@@ -154,6 +182,20 @@ class TestParsing < Minitest::Test
     assert_equal "0xdeadbeef", receipt.reference
     assert_equal "tempo", receipt.method
     assert_instance_of Time, receipt.timestamp
+  end
+
+  def test_parse_payment_receipt_rejects_invalid_method_ids
+    invalid_payment_method_ids.each do |payment_method|
+      payload = {
+        "status" => "success",
+        "timestamp" => "2026-01-15T12:00:30Z",
+        "reference" => "0xabc123",
+        "method" => payment_method
+      }
+      header = Mpp::Parsing.b64_encode(payload)
+
+      assert_raises(Mpp::ParseError) { Mpp::Receipt.from_payment_receipt(header) }
+    end
   end
 
   def test_challenge_to_echo
@@ -244,5 +286,11 @@ class TestParsing < Minitest::Test
   def test_from_www_authenticate_list_empty
     assert_equal [], Mpp::Challenge.from_www_authenticate_list("Bearer token123")
     assert_equal [], Mpp::Challenge.from_www_authenticate_list("")
+  end
+
+  private
+
+  def invalid_payment_method_ids
+    ["Tempo", "tempo2", "tempo-pay", "tempo_pay", "tempo.pay"]
   end
 end

--- a/test/mpp/test_parsing.rb
+++ b/test/mpp/test_parsing.rb
@@ -143,6 +143,24 @@ class TestParsing < Minitest::Test
     end
   end
 
+  def test_parse_authorization_rejects_non_string_challenge_method_ids
+    non_string_payment_method_ids.each do |payment_method|
+      payload = {
+        "challenge" => {
+          "id" => "test-id",
+          "realm" => "api.example.com",
+          "method" => payment_method,
+          "intent" => "charge",
+          "request" => "e30"
+        },
+        "payload" => {"type" => "hash", "hash" => "0xabc"}
+      }
+      header = "Payment #{Mpp::Parsing.b64_encode(payload)}"
+
+      assert_raises(Mpp::ParseError) { Mpp::Credential.from_authorization(header) }
+    end
+  end
+
   def test_receipt_roundtrip
     receipt = Mpp::Receipt.new(
       status: "success",
@@ -186,6 +204,20 @@ class TestParsing < Minitest::Test
 
   def test_parse_payment_receipt_rejects_invalid_method_ids
     invalid_payment_method_ids.each do |payment_method|
+      payload = {
+        "status" => "success",
+        "timestamp" => "2026-01-15T12:00:30Z",
+        "reference" => "0xabc123",
+        "method" => payment_method
+      }
+      header = Mpp::Parsing.b64_encode(payload)
+
+      assert_raises(Mpp::ParseError) { Mpp::Receipt.from_payment_receipt(header) }
+    end
+  end
+
+  def test_parse_payment_receipt_rejects_non_string_method_ids
+    non_string_payment_method_ids.each do |payment_method|
       payload = {
         "status" => "success",
         "timestamp" => "2026-01-15T12:00:30Z",
@@ -292,5 +324,9 @@ class TestParsing < Minitest::Test
 
   def invalid_payment_method_ids
     ["Tempo", "tempo2", "tempo-pay", "tempo_pay", "tempo.pay"]
+  end
+
+  def non_string_payment_method_ids
+    [true, false]
   end
 end


### PR DESCRIPTION
## Summary

- Enforces payment method IDs as lowercase ASCII letters when parsing challenges, credential echoes, and receipts.
- Adds parsing tests that reject uppercase, digit, hyphen, underscore, and dot method IDs.
- Verified with full tests, Standard, and Sorbet in a Ruby 3.3 container.