### PR TITLE
feat: add proof credential replay-store conformance

### DIFF
--- a/lib/mpp/methods/tempo/intents.rb
+++ b/lib/mpp/methods/tempo/intents.rb
@@ -298,6 +298,11 @@ module Mpp
           )
           raise Mpp::VerificationError, "Proof signature does not match source" unless valid
 
+          if @store
+            store_key = "mpp:proof:#{credential.challenge.id}"
+            raise Mpp::VerificationError, "Proof credential has already been used" unless @store.put_if_absent(store_key, true)
+          end
+
           Mpp::Receipt.success(credential.challenge.id)
         end
 

--- a/test/mpp/methods/tempo/test_charge_intent.rb
+++ b/test/mpp/methods/tempo/test_charge_intent.rb
@@ -71,6 +71,51 @@ class TestTempoChargeIntent < Minitest::Test
     assert_equal HASH, result.reference
   end
 
+  def test_proof_credential_replay_rejected
+    account = Mpp::Methods::Tempo::Account.from_key("0x#{"11" * 32}")
+    chain_id = 4217
+    challenge_id = "challenge-proof-123"
+
+    signature = Mpp::Methods::Tempo::Proof.sign(
+      account: account,
+      chain_id: chain_id,
+      challenge_id: challenge_id
+    )
+
+    credential = Mpp::Credential.new(
+      challenge: Mpp::ChallengeEcho.new(
+        id: challenge_id,
+        realm: REALM,
+        method: "tempo",
+        intent: "charge",
+        request: ""
+      ),
+      payload: {"type" => "proof", "signature" => signature},
+      source: Mpp::Methods::Tempo::Proof.source(address: account.address, chain_id: chain_id)
+    )
+
+    request = {
+      "amount" => "0",
+      "currency" => CURRENCY,
+      "recipient" => RECIPIENT,
+      "methodDetails" => {"chainId" => chain_id}
+    }
+
+    store = Mpp::MemoryStore.new
+    intent = Mpp::Methods::Tempo::ChargeIntent.new(rpc_url: "https://rpc.example.test", store: store)
+
+    # First submission succeeds and records the proof under its challenge id.
+    receipt = intent.verify(credential, request)
+    assert_equal challenge_id, receipt.reference
+    assert store.get("mpp:proof:#{challenge_id}")
+
+    # Replaying the identical credential is rejected.
+    error = assert_raises(Mpp::VerificationError) do
+      intent.verify(credential, request)
+    end
+    assert_match(/already been used/, error.message)
+  end
+
   private
 
   def verify_hash(receipt, challenge_id:, memo: nil)


### PR DESCRIPTION
Proof credentials weren't recorded after verification, so the same proof could be replayed until challenge expiry.

`verify_proof` now records `mpp:proof:{challenge.id}` via the store's atomic `put_if_absent` and rejects any repeat. Mirrors the Tempo hash-path dedup and the Rust SDK fix. Adds a test submitting the same proof twice (first succeeds, second rejected).