### PR TITLE
feat: add fee payer token allowlist

### DIFF
--- a/lib/mpp/methods/tempo/client_method.rb
+++ b/lib/mpp/methods/tempo/client_method.rb
@@ -16,18 +16,20 @@ module Mpp
       # Tempo payment method implementation.
       # Handles client-side credential creation for Tempo payments.
       class TempoMethod
-        attr_reader :name, :account, :fee_payer, :root_account, :rpc_url,
-          :chain_id, :currency, :recipient, :decimals, :client_id,
+        attr_reader :name, :account, :fee_payer, :fee_payer_allowed_fee_tokens,
+          :root_account, :rpc_url, :chain_id, :currency, :recipient, :decimals, :client_id,
           :expected_recipients
         attr_accessor :intents
 
         def initialize(account: nil, fee_payer: nil, root_account: nil,
           rpc_url: Defaults::RPC_URL, chain_id: nil, currency: nil,
           recipient: nil, decimals: 6, client_id: nil,
-          expected_recipients: nil)
+          expected_recipients: nil, fee_payer_allowed_fee_tokens: nil)
           @name = "tempo"
           @account = account
           @fee_payer = fee_payer
+          @fee_payer_allowed_fee_tokens =
+            fee_payer_allowed_fee_tokens&.map { |token| token.to_s.downcase }
           @root_account = root_account
           @rpc_url = rpc_url
           @chain_id = chain_id
@@ -230,7 +232,7 @@ module Mpp
       # Factory function to create a configured TempoMethod.
       def self.tempo(intents:, account: nil, fee_payer: nil, chain_id: nil, rpc_url: nil,
         root_account: nil, currency: nil, recipient: nil, decimals: 6, client_id: nil,
-        expected_recipients: nil)
+        expected_recipients: nil, fee_payer_allowed_fee_tokens: nil)
         rpc_url ||= chain_id ? Defaults.rpc_url_for_chain(chain_id) : Defaults::RPC_URL
         currency ||= Defaults.default_currency_for_chain(chain_id)
 
@@ -244,7 +246,8 @@ module Mpp
           recipient: recipient,
           decimals: decimals,
           client_id: client_id,
-          expected_recipients: expected_recipients
+          expected_recipients: expected_recipients,
+          fee_payer_allowed_fee_tokens: fee_payer_allowed_fee_tokens
         )
 
         intents.each_value do |intent|

--- a/lib/mpp/methods/tempo/intents.rb
+++ b/lib/mpp/methods/tempo/intents.rb
@@ -32,6 +32,10 @@ module Mpp
           @_method&.fee_payer
         end
 
+        def fee_payer_allowed_fee_tokens
+          @_method&.fee_payer_allowed_fee_tokens
+        end
+
         def verify(credential, request)
           req = Schemas::ChargeRequest.from_hash(request)
 
@@ -389,6 +393,13 @@ module Mpp
           # Build the final transaction with fee_token set
           resolved_fee_token = fee_token || request&.currency
           raise Mpp::VerificationError, "No fee token available" unless resolved_fee_token
+
+          allowed_fee_tokens = fee_payer_allowed_fee_tokens ||
+            [Defaults.default_currency_for_chain(int.call(decoded[0])).downcase]
+          unless allowed_fee_tokens.map(&:downcase).include?(resolved_fee_token.downcase)
+            raise Mpp::VerificationError,
+              "Fee token #{resolved_fee_token} is not allowed by fee payer policy"
+          end
 
           tx_to_sign = tx_for_recovery.with(fee_token: resolved_fee_token)
 

--- a/test/mpp/methods/tempo/test_transaction.rb
+++ b/test/mpp/methods/tempo/test_transaction.rb
@@ -214,6 +214,32 @@ class TestTempoTransaction < Minitest::Test
     assert_includes error.message, "not allowed by fee payer policy"
   end
 
+  def test_charge_intent_default_allowlist_rejects_non_default_fee_token
+    skip "eth/rlp gems not available" unless eth_and_rlp_available?
+
+    payer = Mpp::Methods::Tempo::Account.from_key("0x#{"11" * 32}")
+    fee_payer = Mpp::Methods::Tempo::Account.from_key("0x#{"22" * 32}")
+    raw_tx, = Mpp::Methods::Tempo::Transaction.build_signed_transfer(
+      account: payer,
+      chain_id: 42_431,
+      gas_limit: 1_000_000,
+      gas_price: 1,
+      nonce: 0,
+      nonce_key: (1 << 256) - 1,
+      currency: CURRENCY,
+      transfer_data: transfer_data,
+      valid_before: Time.now.to_i + 60,
+      awaiting_fee_payer: true
+    )
+    intent = Mpp::Methods::Tempo::ChargeIntent.new
+    Mpp::Methods::Tempo.tempo(intents: {"charge" => intent}, fee_payer: fee_payer)
+
+    error = assert_raises(Mpp::VerificationError) do
+      intent.send(:cosign_as_fee_payer, raw_tx, DISALLOWED_FEE_TOKEN)
+    end
+    assert_includes error.message, "not allowed by fee payer policy"
+  end
+
   private
 
   def transfer_data

--- a/test/mpp/methods/tempo/test_transaction.rb
+++ b/test/mpp/methods/tempo/test_transaction.rb
@@ -10,6 +10,7 @@ class TestTempoTransaction < Minitest::Test
   end
 
   CURRENCY = "0x20c0000000000000000000000000000000000000"
+  DISALLOWED_FEE_TOKEN = "0x20c0000000000000000000000000000000000001"
   RECIPIENT = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
   ACCOUNT = "0x1234567890abcdef1234567890abcdef12345678"
 
@@ -181,6 +182,36 @@ class TestTempoTransaction < Minitest::Test
     assert_equal access_list, decoded[5]
     assert_equal 3, decoded[11].length
     assert_equal 65, decoded[13].bytesize
+  end
+
+  def test_charge_intent_rejects_non_allowlisted_fee_token
+    skip "eth/rlp gems not available" unless eth_and_rlp_available?
+
+    payer = Mpp::Methods::Tempo::Account.from_key("0x#{"11" * 32}")
+    fee_payer = Mpp::Methods::Tempo::Account.from_key("0x#{"22" * 32}")
+    raw_tx, = Mpp::Methods::Tempo::Transaction.build_signed_transfer(
+      account: payer,
+      chain_id: 42_431,
+      gas_limit: 1_000_000,
+      gas_price: 1,
+      nonce: 0,
+      nonce_key: (1 << 256) - 1,
+      currency: CURRENCY,
+      transfer_data: transfer_data,
+      valid_before: Time.now.to_i + 60,
+      awaiting_fee_payer: true
+    )
+    intent = Mpp::Methods::Tempo::ChargeIntent.new
+    Mpp::Methods::Tempo.tempo(
+      intents: {"charge" => intent},
+      fee_payer: fee_payer,
+      fee_payer_allowed_fee_tokens: [CURRENCY]
+    )
+
+    error = assert_raises(Mpp::VerificationError) do
+      intent.send(:cosign_as_fee_payer, raw_tx, DISALLOWED_FEE_TOKEN)
+    end
+    assert_includes error.message, "not allowed by fee payer policy"
   end
 
   private


### PR DESCRIPTION
## Summary
- Add sponsor-side fee-payer token allowlist plumbing.
- Default sponsor fee tokens to the SDK default currency for the decoded chain.
- Reject local sponsor cosigning when the resolved fee token is not allowlisted.
- Add conformance coverage for the non-allowlisted fee-token case.
