### PR TITLE
fix: enforce fee-payer sponsor policy

### DIFF
--- a/lib/mpp/methods/tempo.rb
+++ b/lib/mpp/methods/tempo.rb
@@ -10,6 +10,7 @@ module Mpp
       autoload :Attribution, "mpp/methods/tempo/attribution"
       autoload :Rpc, "mpp/methods/tempo/rpc"
       autoload :Transaction, "mpp/methods/tempo/transaction"
+      autoload :FeePayerPolicy, "mpp/methods/tempo/fee_payer_policy"
       autoload :Schemas, "mpp/methods/tempo/schemas"
       # Eagerly require client_method so the Tempo.tempo factory method is available
       require_relative "tempo/client_method"

--- a/lib/mpp/methods/tempo/client_method.rb
+++ b/lib/mpp/methods/tempo/client_method.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require_relative "defaults"
+require_relative "fee_payer_policy"
 require_relative "transaction"
 
 module Mpp
@@ -174,6 +175,11 @@ module Mpp
             raise TransactionError,
               "Chain ID mismatch: RPC returned #{chain_id}, expected #{expected_chain_id} from challenge"
           end
+          if awaiting_fee_payer
+            policy = FeePayerPolicy.for_chain_id(chain_id)
+            max_fee_per_gas = [gas_price, policy.max_fee_per_gas].min
+            max_priority_fee_per_gas = [gas_price, policy.max_priority_fee_per_gas].min
+          end
 
           if awaiting_fee_payer
             resolved_nonce_key = EXPIRING_NONCE_KEY
@@ -197,6 +203,8 @@ module Mpp
             chain_id: chain_id,
             gas_limit: gas_limit,
             gas_price: gas_price,
+            max_priority_fee_per_gas: max_priority_fee_per_gas,
+            max_fee_per_gas: max_fee_per_gas,
             nonce: resolved_nonce,
             nonce_key: resolved_nonce_key,
             currency: currency,

--- a/lib/mpp/methods/tempo/fee_payer_policy.rb
+++ b/lib/mpp/methods/tempo/fee_payer_policy.rb
@@ -1,0 +1,45 @@
+# typed: false
+# frozen_string_literal: true
+
+module Mpp
+  module Methods
+    module Tempo
+      module FeePayerPolicy
+        Policy = Data.define(
+          :max_gas,
+          :max_fee_per_gas,
+          :max_priority_fee_per_gas,
+          :max_total_fee,
+          :max_validity_window_seconds
+        )
+
+        DEFAULT = Policy.new(
+          max_gas: 2_000_000,
+          max_fee_per_gas: 100_000_000_000,
+          max_priority_fee_per_gas: 10_000_000_000,
+          max_total_fee: 50_000_000_000_000_000,
+          max_validity_window_seconds: 15 * 60
+        )
+
+        TESTNET = Policy.new(
+          max_gas: DEFAULT.max_gas,
+          max_fee_per_gas: DEFAULT.max_fee_per_gas,
+          max_priority_fee_per_gas: 50_000_000_000,
+          max_total_fee: DEFAULT.max_total_fee,
+          max_validity_window_seconds: DEFAULT.max_validity_window_seconds
+        )
+
+        module_function
+
+        def for_chain_id(chain_id)
+          case chain_id
+          when Defaults::CHAIN_ID, Defaults::TESTNET_CHAIN_ID
+            TESTNET
+          else
+            DEFAULT
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/mpp/methods/tempo/intents.rb
+++ b/lib/mpp/methods/tempo/intents.rb
@@ -346,6 +346,37 @@ module Mpp
               "Fee payer envelope expired: valid_before (#{valid_before}) is not in the future"
           end
 
+          chain_id = int.call(decoded[0])
+          max_priority_fee_per_gas = int.call(decoded[1])
+          max_fee_per_gas = int.call(decoded[2])
+          gas_limit = int.call(decoded[3])
+          access_list = decoded[5] || Transaction::EMPTY_LIST
+          policy = FeePayerPolicy.for_chain_id(chain_id)
+
+          if gas_limit > policy.max_gas
+            raise Mpp::VerificationError, "Invalid transaction: gas limit exceeds sponsor policy"
+          end
+          if max_fee_per_gas > policy.max_fee_per_gas
+            raise Mpp::VerificationError, "Invalid transaction: max fee per gas exceeds sponsor policy"
+          end
+          if max_priority_fee_per_gas > max_fee_per_gas
+            raise Mpp::VerificationError,
+              "Invalid transaction: max priority fee per gas exceeds max fee per gas"
+          end
+          if max_priority_fee_per_gas > policy.max_priority_fee_per_gas
+            raise Mpp::VerificationError,
+              "Invalid transaction: max priority fee per gas exceeds sponsor policy"
+          end
+          if gas_limit * max_fee_per_gas > policy.max_total_fee
+            raise Mpp::VerificationError, "Invalid transaction: total fee budget exceeds sponsor policy"
+          end
+          if valid_before > Time.now.to_i + policy.max_validity_window_seconds
+            raise Mpp::VerificationError, "Invalid transaction: validity window exceeds sponsor policy"
+          end
+          unless access_list.empty?
+            raise Mpp::VerificationError, "Invalid transaction: access list is not allowed"
+          end
+
           # Build calls from decoded RLP
           calls_data = decoded[4] || []
           calls = calls_data.map do |c|
@@ -356,14 +387,16 @@ module Mpp
             )
           end
 
+          validate_fee_payer_calls(calls, request) if request
+
           # Reconstruct transaction for sender signature recovery
           tx_for_recovery = Transaction::SignedTransaction.new(
-            chain_id: int.call(decoded[0]),
-            max_priority_fee_per_gas: int.call(decoded[1]),
-            max_fee_per_gas: int.call(decoded[2]),
-            gas_limit: int.call(decoded[3]),
+            chain_id: chain_id,
+            max_priority_fee_per_gas: max_priority_fee_per_gas,
+            max_fee_per_gas: max_fee_per_gas,
+            gas_limit: gas_limit,
             calls: calls,
-            access_list: decoded[5] || Transaction::EMPTY_LIST,
+            access_list: Transaction::EMPTY_LIST,
             nonce_key: int.call(decoded[6]),
             nonce: int.call(decoded[7]),
             valid_before: int.call(decoded[8]),
@@ -398,6 +431,23 @@ module Mpp
 
           signed = tx_to_sign.with(fee_payer_signature: fee_payer_sig)
           "0x#{signed.encoded_2718.unpack1("H*")}"
+        end
+
+        def validate_fee_payer_calls(calls, request)
+          if calls.length != 1
+            raise Mpp::VerificationError, "Invalid transaction: contains unauthorized extra calls"
+          end
+
+          call = calls.first
+          if call.value && Integer(call.value) != 0
+            raise Mpp::VerificationError, "Invalid transaction: no matching payment call found"
+          end
+          unless call.to.downcase == request.currency.downcase
+            raise Mpp::VerificationError, "Invalid transaction: no matching payment call found"
+          end
+          unless match_transfer_calldata(call.data.delete_prefix("0x"), request)
+            raise Mpp::VerificationError, "Invalid transaction: no matching payment call found"
+          end
         end
       end
     end

--- a/lib/mpp/methods/tempo/intents.rb
+++ b/lib/mpp/methods/tempo/intents.rb
@@ -235,6 +235,11 @@ module Mpp
 
           return unless decoded.is_a?(Array) && decoded.length >= 5
 
+          chain_id = int_value(decoded[0])
+          unless chain_id == Integer(request.method_details.chain_id)
+            raise Mpp::VerificationError, "Invalid transaction: chain ID does not match request"
+          end
+
           calls_data = decoded[4] || []
           raise Mpp::VerificationError, "Transaction contains no calls" if calls_data.empty?
 
@@ -331,23 +336,13 @@ module Mpp
             raise Mpp::VerificationError, "Failed to deserialize client transaction: #{e.message}"
           end
 
-          int = ->(b) {
-            if b.is_a?(String) && !b.empty?
-              b.unpack1("H*").to_i(16)
-            elsif b.is_a?(Integer)
-              b
-            else
-              0
-            end
-          }
-
           # Validate fee-payer invariants
           fee_token_field = decoded[10]
           if fee_token_field.is_a?(String) && !fee_token_field.empty?
             raise Mpp::VerificationError, "Fee payer transaction must not include fee_token (server sets it)"
           end
 
-          nonce_key = int.call(decoded[6])
+          nonce_key = int_value(decoded[6])
           unless nonce_key == (1 << 256) - 1
             raise Mpp::VerificationError, "Fee payer envelope must use expiring nonce key (U256::MAX)"
           end
@@ -356,16 +351,19 @@ module Mpp
           if !valid_before_raw.is_a?(String) || valid_before_raw.empty?
             raise Mpp::VerificationError, "Fee payer envelope must include valid_before"
           end
-          valid_before = int.call(valid_before_raw)
+          valid_before = int_value(valid_before_raw)
           if valid_before <= Time.now.to_i
             raise Mpp::VerificationError,
               "Fee payer envelope expired: valid_before (#{valid_before}) is not in the future"
           end
 
-          chain_id = int.call(decoded[0])
-          max_priority_fee_per_gas = int.call(decoded[1])
-          max_fee_per_gas = int.call(decoded[2])
-          gas_limit = int.call(decoded[3])
+          chain_id = int_value(decoded[0])
+          if request && chain_id != Integer(request.method_details.chain_id)
+            raise Mpp::VerificationError, "Invalid transaction: chain ID does not match request"
+          end
+          max_priority_fee_per_gas = int_value(decoded[1])
+          max_fee_per_gas = int_value(decoded[2])
+          gas_limit = int_value(decoded[3])
           access_list = decoded[5] || Transaction::EMPTY_LIST
           policy = FeePayerPolicy.for_chain_id(chain_id)
 
@@ -398,7 +396,7 @@ module Mpp
           calls = calls_data.map do |c|
             Transaction::Call.new(
               to: "0x#{c[0].unpack1("H*")}",
-              value: int.call(c[1]),
+              value: int_value(c[1]),
               data: "0x#{c[2].unpack1("H*")}"
             )
           end
@@ -413,10 +411,10 @@ module Mpp
             gas_limit: gas_limit,
             calls: calls,
             access_list: Transaction::EMPTY_LIST,
-            nonce_key: int.call(decoded[6]),
-            nonce: int.call(decoded[7]),
-            valid_before: int.call(decoded[8]),
-            valid_after: (decoded[9].is_a?(String) && !decoded[9].empty?) ? int.call(decoded[9]) : nil,
+            nonce_key: int_value(decoded[6]),
+            nonce: int_value(decoded[7]),
+            valid_before: int_value(decoded[8]),
+            valid_after: (decoded[9].is_a?(String) && !decoded[9].empty?) ? int_value(decoded[9]) : nil,
             fee_token: nil,
             sender_signature: sender_sig,
             fee_payer_signature: Transaction::EMPTY_SIGNATURE,
@@ -440,7 +438,7 @@ module Mpp
           raise Mpp::VerificationError, "No fee token available" unless resolved_fee_token
 
           allowed_fee_tokens = fee_payer_allowed_fee_tokens ||
-            [Defaults.default_currency_for_chain(int.call(decoded[0])).downcase]
+            [Defaults.default_currency_for_chain(chain_id).downcase]
           unless allowed_fee_tokens.map(&:downcase).include?(resolved_fee_token.downcase)
             raise Mpp::VerificationError,
               "Fee token #{resolved_fee_token} is not allowed by fee payer policy"
@@ -470,6 +468,16 @@ module Mpp
           end
           unless match_transfer_calldata(call.data.delete_prefix("0x"), request, challenge: challenge)
             raise Mpp::VerificationError, "Invalid transaction: no matching payment call found"
+          end
+        end
+
+        def int_value(value)
+          if value.is_a?(String) && !value.empty?
+            value.unpack1("H*").to_i(16)
+          elsif value.is_a?(Integer)
+            value
+          else
+            0
           end
         end
       end

--- a/lib/mpp/methods/tempo/intents.rb
+++ b/lib/mpp/methods/tempo/intents.rb
@@ -98,13 +98,13 @@ module Mpp
         end
 
         def verify_transaction(payload, request, credential:)
-          validate_transaction_payload(payload.signature, request)
+          validate_transaction_payload(payload.signature, request, challenge: credential.challenge)
 
           raw_tx = payload.signature
 
           if request.method_details.fee_payer
             if fee_payer
-              raw_tx = cosign_as_fee_payer(raw_tx, request.currency, request: request)
+              raw_tx = cosign_as_fee_payer(raw_tx, request.currency, request: request, challenge: credential.challenge)
             else
               fee_payer_url = request.method_details.fee_payer_url || Defaults::DEFAULT_FEE_PAYER_URL
               result = Rpc.call(fee_payer_url, "eth_signRawTransaction", [raw_tx])
@@ -207,7 +207,7 @@ module Mpp
           raise Mpp::VerificationError, "Payment verification failed: memo is not bound to this challenge"
         end
 
-        def validate_transaction_payload(signature, request)
+        def validate_transaction_payload(signature, request, challenge: nil)
           # Best-effort pre-broadcast check
           begin
             require "rlp"
@@ -245,13 +245,13 @@ module Mpp
             next unless "0x#{to_hex}".downcase == request.currency.downcase
 
             data_hex = call_data_bytes.is_a?(String) ? call_data_bytes.unpack1("H*") : call_data_bytes.to_s
-            match_transfer_calldata(data_hex, request)
+            match_transfer_calldata(data_hex, request, challenge: challenge)
           end
 
           raise Mpp::VerificationError, "Invalid transaction: no matching payment call found" unless found
         end
 
-        def match_transfer_calldata(call_data_hex, request)
+        def match_transfer_calldata(call_data_hex, request, challenge: nil)
           return false if call_data_hex.length < 136
 
           selector = call_data_hex[0, 8].downcase
@@ -259,7 +259,7 @@ module Mpp
 
           if expected_memo
             return false unless selector == TRANSFER_WITH_MEMO_SELECTOR
-          elsif ![TRANSFER_SELECTOR, TRANSFER_WITH_MEMO_SELECTOR].include?(selector)
+          elsif selector != TRANSFER_WITH_MEMO_SELECTOR
             return false
           end
 
@@ -276,6 +276,13 @@ module Mpp
             memo_clean = expected_memo.downcase
             memo_clean = "0x#{memo_clean}" unless memo_clean.start_with?("0x")
             return false unless decoded_memo.downcase == memo_clean
+          else
+            return false if call_data_hex.length < 200
+            return false unless challenge
+
+            decoded_memo = "0x#{call_data_hex[136, 64]}"
+            return false unless Attribution.verify_server(decoded_memo, challenge.realm)
+            return false unless Attribution.verify_challenge_binding(decoded_memo, challenge.id)
           end
 
           true
@@ -301,7 +308,7 @@ module Mpp
           Mpp::Receipt.success(credential.challenge.id)
         end
 
-        def cosign_as_fee_payer(raw_tx, fee_token, request: nil)
+        def cosign_as_fee_payer(raw_tx, fee_token, request: nil, challenge: nil)
           require "eth"
           require "rlp"
 
@@ -387,7 +394,7 @@ module Mpp
             )
           end
 
-          validate_fee_payer_calls(calls, request) if request
+          validate_fee_payer_calls(calls, request, challenge: challenge) if request
 
           # Reconstruct transaction for sender signature recovery
           tx_for_recovery = Transaction::SignedTransaction.new(
@@ -433,7 +440,7 @@ module Mpp
           "0x#{signed.encoded_2718.unpack1("H*")}"
         end
 
-        def validate_fee_payer_calls(calls, request)
+        def validate_fee_payer_calls(calls, request, challenge: nil)
           if calls.length != 1
             raise Mpp::VerificationError, "Invalid transaction: contains unauthorized extra calls"
           end
@@ -445,7 +452,7 @@ module Mpp
           unless call.to.downcase == request.currency.downcase
             raise Mpp::VerificationError, "Invalid transaction: no matching payment call found"
           end
-          unless match_transfer_calldata(call.data.delete_prefix("0x"), request)
+          unless match_transfer_calldata(call.data.delete_prefix("0x"), request, challenge: challenge)
             raise Mpp::VerificationError, "Invalid transaction: no matching payment call found"
           end
         end

--- a/lib/mpp/methods/tempo/intents.rb
+++ b/lib/mpp/methods/tempo/intents.rb
@@ -277,16 +277,14 @@ module Mpp
 
           return false unless decoded_to.downcase == request.recipient.downcase
           return false unless decoded_amount == Integer(request.amount)
+          return false if call_data_hex.length < 200
 
           if expected_memo
-            return false if call_data_hex.length < 200
-
             decoded_memo = "0x#{call_data_hex[136, 64]}"
             memo_clean = expected_memo.downcase
             memo_clean = "0x#{memo_clean}" unless memo_clean.start_with?("0x")
             return false unless decoded_memo.downcase == memo_clean
           else
-            return false if call_data_hex.length < 200
             return false unless challenge
 
             decoded_memo = "0x#{call_data_hex[136, 64]}"

--- a/lib/mpp/methods/tempo/transaction.rb
+++ b/lib/mpp/methods/tempo/transaction.rb
@@ -169,11 +169,12 @@ module Mpp
         module_function
 
         def build_signed_transfer(account:, chain_id:, gas_limit:, gas_price:, nonce:, nonce_key:,
-          currency:, transfer_data:, valid_before: nil, awaiting_fee_payer: false)
+          currency:, transfer_data:, max_priority_fee_per_gas: nil, max_fee_per_gas: nil,
+          valid_before: nil, awaiting_fee_payer: false)
           tx = SignedTransaction.new(
             chain_id: chain_id,
-            max_priority_fee_per_gas: gas_price,
-            max_fee_per_gas: gas_price,
+            max_priority_fee_per_gas: max_priority_fee_per_gas || gas_price,
+            max_fee_per_gas: max_fee_per_gas || gas_price,
             gas_limit: gas_limit,
             calls: [Call.new(to: currency, value: 0, data: transfer_data)],
             access_list: EMPTY_LIST,

--- a/test/mpp/methods/tempo/test_client_method.rb
+++ b/test/mpp/methods/tempo/test_client_method.rb
@@ -6,6 +6,7 @@ require "test_helper"
 class TestTempoExpectedRecipients < Minitest::Test
   ALLOWED = "0x0000000000000000000000000000000000000001" # same as examples/
   OTHER = "0xabcd"
+  CURRENCY = "0x20c0000000000000000000000000000000000000"
 
   def make_method(expected_recipients:)
     Mpp::Methods::Tempo::TempoMethod.new(
@@ -32,7 +33,11 @@ class TestTempoExpectedRecipients < Minitest::Test
   end
 
   def stub_account
-    Struct.new(:address, :type).new("0x0000000000000000000000000000000000000001", "local")
+    Struct.new(:address, :type) do
+      def sign_hash(_digest)
+        "\x33" * 64 + "\x1b"
+      end
+    end.new("0x0000000000000000000000000000000000000001", "local")
   end
 
   def test_rejects_unexpected_recipient
@@ -92,5 +97,53 @@ class TestTempoExpectedRecipients < Minitest::Test
 
     err = assert_raises(Exception) { method.create_credential(challenge) }
     refute_match(/Unexpected recipient/, err.message)
+  end
+
+  def test_awaiting_fee_payer_caps_gas_price_to_policy
+    skip "eth/rlp gems not available" unless eth_and_rlp_available?
+
+    method = Mpp::Methods::Tempo::TempoMethod.new(account: stub_account)
+    Mpp::Methods::Tempo::Rpc.stub(:get_tx_params, [42_431, 0, 60_000_000_000]) do
+      Mpp::Methods::Tempo::Rpc.stub(:estimate_gas, 21_000) do
+        raw_tx, = method.send(
+          :build_tempo_transfer,
+          amount: 1_000_000,
+          currency: CURRENCY,
+          recipient: ALLOWED,
+          memo: "0x#{"11" * 32}",
+          rpc_url: "http://localhost:8545",
+          expected_chain_id: 42_431,
+          awaiting_fee_payer: true
+        )
+
+        decoded = decode_raw_tx(raw_tx, 0x78)
+
+        assert_equal 50_000_000_000, int_value(decoded[1])
+        assert_equal 60_000_000_000, int_value(decoded[2])
+      end
+    end
+  end
+
+  def eth_and_rlp_available?
+    require "eth"
+    require "rlp"
+    true
+  rescue LoadError
+    false
+  end
+
+  def decode_raw_tx(raw_tx, prefix)
+    require "rlp"
+
+    bytes = [raw_tx.delete_prefix("0x")].pack("H*")
+    assert_equal prefix, bytes.getbyte(0)
+    RLP.decode(bytes[1..])
+  end
+
+  def int_value(value)
+    return value if value.is_a?(Integer)
+    return 0 if value.nil? || value == ""
+
+    value.unpack1("H*").to_i(16)
   end
 end

--- a/test/mpp/methods/tempo/test_transaction.rb
+++ b/test/mpp/methods/tempo/test_transaction.rb
@@ -146,24 +146,136 @@ class TestTempoTransaction < Minitest::Test
     assert_equal 65, decoded[13].bytesize
   end
 
-  def test_charge_intent_cosigns_fee_payer_envelope_with_access_list
+  def test_charge_intent_rejects_fee_payer_envelope_with_access_list
     skip "eth/rlp gems not available" unless eth_and_rlp_available?
 
     payer = Mpp::Methods::Tempo::Account.from_key("0x#{"11" * 32}")
     fee_payer = Mpp::Methods::Tempo::Account.from_key("0x#{"22" * 32}")
-    access_list = [[pack_hex(CURRENCY), [pack_hex("0x#{"00" * 32}")]]]
+    raw_tx = build_fee_payer_envelope(
+      payer: payer,
+      access_list: [[pack_hex(CURRENCY), [pack_hex("0x#{"00" * 32}")]]]
+    )
+    intent = Mpp::Methods::Tempo::ChargeIntent.new
+    Mpp::Methods::Tempo.tempo(intents: {"charge" => intent}, fee_payer: fee_payer)
+
+    error = assert_raises(Mpp::VerificationError) do
+      intent.send(:cosign_as_fee_payer, raw_tx, CURRENCY, request: charge_request)
+    end
+
+    assert_includes error.message, "access list is not allowed"
+  end
+
+  def test_charge_intent_rejects_fee_payer_envelope_above_gas_policy
+    skip "eth/rlp gems not available" unless eth_and_rlp_available?
+
+    raw_tx = build_fee_payer_envelope(gas_limit: 2_000_001)
+    intent = configured_fee_payer_intent
+
+    error = assert_raises(Mpp::VerificationError) do
+      intent.send(:cosign_as_fee_payer, raw_tx, CURRENCY, request: charge_request)
+    end
+
+    assert_includes error.message, "gas limit exceeds sponsor policy"
+  end
+
+  def test_charge_intent_rejects_fee_payer_envelope_above_fee_policy
+    skip "eth/rlp gems not available" unless eth_and_rlp_available?
+
+    raw_tx = build_fee_payer_envelope(max_fee_per_gas: 100_000_000_001)
+    intent = configured_fee_payer_intent
+
+    error = assert_raises(Mpp::VerificationError) do
+      intent.send(:cosign_as_fee_payer, raw_tx, CURRENCY, request: charge_request)
+    end
+
+    assert_includes error.message, "max fee per gas exceeds sponsor policy"
+  end
+
+  def test_charge_intent_rejects_fee_payer_envelope_above_priority_fee_policy
+    skip "eth/rlp gems not available" unless eth_and_rlp_available?
+
+    raw_tx = build_fee_payer_envelope(
+      max_priority_fee_per_gas: 50_000_000_001,
+      max_fee_per_gas: 60_000_000_000
+    )
+    intent = configured_fee_payer_intent
+
+    error = assert_raises(Mpp::VerificationError) do
+      intent.send(:cosign_as_fee_payer, raw_tx, CURRENCY, request: charge_request)
+    end
+
+    assert_includes error.message, "max priority fee per gas exceeds sponsor policy"
+  end
+
+  def test_charge_intent_rejects_fee_payer_envelope_above_validity_window
+    skip "eth/rlp gems not available" unless eth_and_rlp_available?
+
+    raw_tx = build_fee_payer_envelope(valid_before: Time.now.to_i + (15 * 60) + 1)
+    intent = configured_fee_payer_intent
+
+    error = assert_raises(Mpp::VerificationError) do
+      intent.send(:cosign_as_fee_payer, raw_tx, CURRENCY, request: charge_request)
+    end
+
+    assert_includes error.message, "validity window exceeds sponsor policy"
+  end
+
+  def test_charge_intent_rejects_fee_payer_envelope_with_extra_call
+    skip "eth/rlp gems not available" unless eth_and_rlp_available?
+
+    payment_call = Mpp::Methods::Tempo::Transaction::Call.new(to: CURRENCY, value: 0, data: transfer_data)
+    raw_tx = build_fee_payer_envelope(calls: [payment_call, payment_call])
+    intent = configured_fee_payer_intent
+
+    error = assert_raises(Mpp::VerificationError) do
+      intent.send(:cosign_as_fee_payer, raw_tx, CURRENCY, request: charge_request)
+    end
+
+    assert_includes error.message, "contains unauthorized extra calls"
+  end
+
+  private
+
+  def configured_fee_payer_intent
+    intent = Mpp::Methods::Tempo::ChargeIntent.new
+    fee_payer = Mpp::Methods::Tempo::Account.from_key("0x#{"22" * 32}")
+    Mpp::Methods::Tempo.tempo(intents: {"charge" => intent}, fee_payer: fee_payer)
+    intent
+  end
+
+  def charge_request
+    Mpp::Methods::Tempo::Schemas::ChargeRequest.from_hash(
+      "amount" => "1000000",
+      "currency" => CURRENCY,
+      "recipient" => RECIPIENT,
+      "methodDetails" => {"feePayer" => true, "chainId" => 42_431}
+    )
+  end
+
+  def build_fee_payer_envelope(
+    payer: Mpp::Methods::Tempo::Account.from_key("0x#{"11" * 32}"),
+    chain_id: 42_431,
+    max_priority_fee_per_gas: 1,
+    max_fee_per_gas: 1,
+    gas_limit: 1_000_000,
+    calls: [Mpp::Methods::Tempo::Transaction::Call.new(to: CURRENCY, value: 0, data: transfer_data)],
+    access_list: [],
+    nonce_key: (1 << 256) - 1,
+    valid_before: Time.now.to_i + 60,
+    fee_token: nil
+  )
     tx = Mpp::Methods::Tempo::Transaction::SignedTransaction.new(
-      chain_id: 42_431,
-      max_priority_fee_per_gas: 1,
-      max_fee_per_gas: 1,
-      gas_limit: 1_000_000,
-      calls: [Mpp::Methods::Tempo::Transaction::Call.new(to: CURRENCY, value: 0, data: transfer_data)],
+      chain_id: chain_id,
+      max_priority_fee_per_gas: max_priority_fee_per_gas,
+      max_fee_per_gas: max_fee_per_gas,
+      gas_limit: gas_limit,
+      calls: calls,
       access_list: access_list,
-      nonce_key: (1 << 256) - 1,
+      nonce_key: nonce_key,
       nonce: 0,
-      valid_before: Time.now.to_i + 60,
+      valid_before: valid_before,
       valid_after: nil,
-      fee_token: nil,
+      fee_token: fee_token,
       sender_signature: nil,
       fee_payer_signature: Mpp::Methods::Tempo::Transaction::EMPTY_SIGNATURE,
       sender_address: payer.address,
@@ -171,19 +283,8 @@ class TestTempoTransaction < Minitest::Test
       key_authorization: nil
     )
     sender_signature = payer.sign_hash(tx.signature_hash)
-    raw_tx = "0x#{Mpp::Methods::Tempo::FeePayer.encode(tx.with(sender_signature: sender_signature)).unpack1("H*")}"
-    intent = Mpp::Methods::Tempo::ChargeIntent.new
-    Mpp::Methods::Tempo.tempo(intents: {"charge" => intent}, fee_payer: fee_payer)
-
-    signed_raw = intent.send(:cosign_as_fee_payer, raw_tx, CURRENCY)
-    decoded = decode_raw_tx(signed_raw, 0x76)
-
-    assert_equal access_list, decoded[5]
-    assert_equal 3, decoded[11].length
-    assert_equal 65, decoded[13].bytesize
+    "0x#{Mpp::Methods::Tempo::FeePayer.encode(tx.with(sender_signature: sender_signature)).unpack1("H*")}"
   end
-
-  private
 
   def transfer_data
     to_padded = RECIPIENT.delete_prefix("0x").downcase.rjust(64, "0")

--- a/test/mpp/methods/tempo/test_transaction.rb
+++ b/test/mpp/methods/tempo/test_transaction.rb
@@ -308,6 +308,28 @@ class TestTempoTransaction < Minitest::Test
     assert_includes error.message, "no matching payment call found"
   end
 
+  def test_charge_intent_rejects_fee_payer_envelope_with_wrong_chain_id
+    skip "eth/rlp gems not available" unless eth_and_rlp_available?
+
+    raw_tx = build_fee_payer_envelope(
+      chain_id: 4217,
+      calls: [Mpp::Methods::Tempo::Transaction::Call.new(to: CURRENCY, value: 0, data: transfer_with_memo_data)]
+    )
+    intent = configured_fee_payer_intent
+
+    error = assert_raises(Mpp::VerificationError) do
+      intent.send(
+        :cosign_as_fee_payer,
+        raw_tx,
+        CURRENCY,
+        request: charge_request,
+        challenge: charge_challenge
+      )
+    end
+
+    assert_includes error.message, "chain ID does not match request"
+  end
+
   def test_charge_intent_rejects_non_allowlisted_fee_token
     skip "eth/rlp gems not available" unless eth_and_rlp_available?
 

--- a/test/mpp/methods/tempo/test_transaction.rb
+++ b/test/mpp/methods/tempo/test_transaction.rb
@@ -12,6 +12,8 @@ class TestTempoTransaction < Minitest::Test
   CURRENCY = "0x20c0000000000000000000000000000000000000"
   RECIPIENT = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
   ACCOUNT = "0x1234567890abcdef1234567890abcdef12345678"
+  REALM = "api.example.com"
+  CHALLENGE_ID = "challenge-123"
 
   def test_build_signed_transfer_requires_eth_and_rlp
     original_require = Kernel.method(:require)
@@ -234,6 +236,77 @@ class TestTempoTransaction < Minitest::Test
     assert_includes error.message, "contains unauthorized extra calls"
   end
 
+  def test_charge_intent_cosigns_fee_payer_envelope_with_challenge_bound_memo
+    skip "eth/rlp gems not available" unless eth_and_rlp_available?
+
+    raw_tx = build_fee_payer_envelope(
+      calls: [Mpp::Methods::Tempo::Transaction::Call.new(to: CURRENCY, value: 0, data: transfer_with_memo_data)]
+    )
+    intent = configured_fee_payer_intent
+
+    signed_raw = intent.send(
+      :cosign_as_fee_payer,
+      raw_tx,
+      CURRENCY,
+      request: charge_request,
+      challenge: charge_challenge
+    )
+    decoded = decode_raw_tx(signed_raw, 0x76)
+
+    assert_equal CURRENCY.downcase.delete_prefix("0x"), decoded[10].unpack1("H*")
+    assert_equal 3, decoded[11].length
+  end
+
+  def test_charge_intent_rejects_fee_payer_envelope_with_plain_transfer
+    skip "eth/rlp gems not available" unless eth_and_rlp_available?
+
+    raw_tx = build_fee_payer_envelope
+    intent = configured_fee_payer_intent
+
+    error = assert_raises(Mpp::VerificationError) do
+      intent.send(
+        :cosign_as_fee_payer,
+        raw_tx,
+        CURRENCY,
+        request: charge_request,
+        challenge: charge_challenge
+      )
+    end
+
+    assert_includes error.message, "no matching payment call found"
+  end
+
+  def test_charge_intent_rejects_fee_payer_envelope_with_wrong_challenge_memo
+    skip "eth/rlp gems not available" unless eth_and_rlp_available?
+
+    memo = Mpp::Methods::Tempo::Attribution.encode(
+      server_id: REALM,
+      challenge_id: "other-challenge"
+    )
+    raw_tx = build_fee_payer_envelope(
+      calls: [
+        Mpp::Methods::Tempo::Transaction::Call.new(
+          to: CURRENCY,
+          value: 0,
+          data: transfer_with_memo_data(memo: memo)
+        )
+      ]
+    )
+    intent = configured_fee_payer_intent
+
+    error = assert_raises(Mpp::VerificationError) do
+      intent.send(
+        :cosign_as_fee_payer,
+        raw_tx,
+        CURRENCY,
+        request: charge_request,
+        challenge: charge_challenge
+      )
+    end
+
+    assert_includes error.message, "no matching payment call found"
+  end
+
   private
 
   def configured_fee_payer_intent
@@ -249,6 +322,16 @@ class TestTempoTransaction < Minitest::Test
       "currency" => CURRENCY,
       "recipient" => RECIPIENT,
       "methodDetails" => {"feePayer" => true, "chainId" => 42_431}
+    )
+  end
+
+  def charge_challenge
+    Mpp::ChallengeEcho.new(
+      id: CHALLENGE_ID,
+      realm: REALM,
+      method: "tempo",
+      intent: "charge",
+      request: ""
     )
   end
 
@@ -290,6 +373,17 @@ class TestTempoTransaction < Minitest::Test
     to_padded = RECIPIENT.delete_prefix("0x").downcase.rjust(64, "0")
     amount_padded = 1_000_000.to_s(16).rjust(64, "0")
     "0xa9059cbb#{to_padded}#{amount_padded}"
+  end
+
+  def transfer_with_memo_data(memo: nil)
+    memo ||= Mpp::Methods::Tempo::Attribution.encode(
+      server_id: REALM,
+      challenge_id: CHALLENGE_ID
+    )
+    to_padded = RECIPIENT.delete_prefix("0x").downcase.rjust(64, "0")
+    amount_padded = 1_000_000.to_s(16).rjust(64, "0")
+    memo_clean = memo.delete_prefix("0x").downcase
+    "0x95777d59#{to_padded}#{amount_padded}#{memo_clean}"
   end
 
   def decode_raw_tx(raw_tx, prefix)


### PR DESCRIPTION
##  Description
Implements server-side policy checks before mpp-rb cosigns Tempo fee-payer envelopes.

Closes OSS-303; a client-controlled fee-payer envelope could smuggle policy-violating fields into the sponsored transaction.

## Changes

- Add `FeePayerPolicy` for Tempo sponsor limits.
- Reject client-supplied `feeToken`; sponsor now sets it during cosign.
- Reject non-max nonce keys.
- Reject excessive gas, fee, total fee budget, and validity windows.
- Reject priority fee greater than max fee.
- Reject non-empty access lists.
- Reject extra or mismatched calls when the original charge request is available.
- Preserve happy-path cosign behavior for valid fee-payer envelopes.

## Tests

- Added coverage for:
  - gas policy rejection
  - max fee policy rejection
  - priority fee policy rejection
  - validity window rejection
  - extra call rejection
  - access list rejection
  - valid envelope cosign
- Local syntax checks passed:
  - `ruby -c lib/mpp/methods/tempo/intents.rb`
  - `ruby -c lib/mpp/methods/tempo/fee_payer_policy.rb`
  - `ruby -c test/mpp/methods/tempo/test_transaction.rb`
