### PR TITLE
fix(stripe): enforce paymentMethodTypes allowlist

### DIFF
--- a/lib/mpp/methods/stripe/charge_intent.rb
+++ b/lib/mpp/methods/stripe/charge_intent.rb
@@ -40,7 +40,7 @@ module Mpp
           payment_method_types = method_details["paymentMethodTypes"]
           unless payment_method_types.is_a?(Array) &&
               payment_method_types.any? &&
-              payment_method_types.all? { |type| type.is_a?(String) && !type.empty? }
+              payment_method_types.all? { |type| type.is_a?(String) && !type.strip.empty? }
             raise Mpp::VerificationError, "Invalid or missing methodDetails.paymentMethodTypes"
           end
 

--- a/lib/mpp/methods/stripe/charge_intent.rb
+++ b/lib/mpp/methods/stripe/charge_intent.rb
@@ -33,21 +33,28 @@ module Mpp
           spt = payload_data["spt"]
           external_id = payload_data["externalId"]
 
+          method_details = request["methodDetails"]
+          method_details = {} unless method_details.is_a?(Hash)
+
+          # Enforce the payment method types allowlist from the challenge
+          payment_method_types = method_details["paymentMethodTypes"]
+          unless payment_method_types.is_a?(Array) &&
+              payment_method_types.any? &&
+              payment_method_types.all? { |type| type.is_a?(String) && !type.empty? }
+            raise Mpp::VerificationError, "Invalid or missing methodDetails.paymentMethodTypes"
+          end
+
           # Build PaymentIntent params
           params = {
             amount: Integer(request["amount"]),
             currency: request["currency"],
             shared_payment_granted_token: spt,
             confirm: true,
-            automatic_payment_methods: {
-              enabled: true,
-              allow_redirects: "never"
-            }
+            payment_method_types: payment_method_types
           }
 
           # Include metadata from methodDetails if present
-          method_details = request["methodDetails"]
-          if method_details.is_a?(Hash) && method_details["metadata"].is_a?(Hash)
+          if method_details["metadata"].is_a?(Hash)
             params[:metadata] = method_details["metadata"].transform_values(&:to_s)
           end
 

--- a/lib/mpp/methods/stripe/stripe_method.rb
+++ b/lib/mpp/methods/stripe/stripe_method.rb
@@ -15,6 +15,12 @@ module Mpp
         def initialize(secret_key:, network_id:, payment_methods: nil,
           metadata: nil, currency: Defaults::DEFAULT_CURRENCY,
           decimals: Defaults::DEFAULT_DECIMALS)
+          unless payment_methods.is_a?(Array) &&
+              payment_methods.any? &&
+              payment_methods.all? { |type| type.is_a?(String) && !type.strip.empty? }
+            raise ArgumentError, "payment_methods must be a non-empty array of Stripe payment method type strings"
+          end
+
           @name = "stripe"
           @secret_key = secret_key
           @network_id = network_id
@@ -32,7 +38,7 @@ module Mpp
           method_details = {} unless method_details.is_a?(Hash)
 
           method_details["networkId"] = @network_id
-          method_details["paymentMethods"] = @payment_methods if @payment_methods
+          method_details["paymentMethodTypes"] = @payment_methods
           method_details["metadata"] = @metadata if @metadata
 
           request.merge("methodDetails" => method_details)

--- a/test/mpp/methods/stripe/test_charge_intent.rb
+++ b/test/mpp/methods/stripe/test_charge_intent.rb
@@ -34,13 +34,16 @@ class TestStripeChargeIntent < Minitest::Test
     Mpp::Credential.new(challenge: echo, payload: payload)
   end
 
-  def make_request(amount: "100", currency: "usd", method_details: nil)
+  def make_request(amount: "100", currency: "usd", payment_method_types: ["card"], method_details: nil)
     req = {
       "amount" => amount,
       "currency" => currency,
       "recipient" => "acct_test123"
     }
-    req["methodDetails"] = method_details if method_details
+    details = {}
+    details["paymentMethodTypes"] = payment_method_types unless payment_method_types.nil?
+    details.merge!(method_details) if method_details
+    req["methodDetails"] = details unless details.empty?
     req
   end
 
@@ -71,11 +74,20 @@ class TestStripeChargeIntent < Minitest::Test
     skip "stripe gem not available" unless @stripe_available
 
     credential = make_credential(payload: {"spt" => "spt_test123", "externalId" => "ext_1"})
-    request = make_request(method_details: {"metadata" => {"order" => "123"}})
+    request = make_request(payment_method_types: ["card", "link"], method_details: {"metadata" => {"order" => "123"}})
 
     mock_result = Struct.new(:id, :status).new("pi_abc123", "succeeded")
     mock_pi = Minitest::Mock.new
-    mock_pi.expect(:create, mock_result, [Hash])
+    mock_pi.expect(:create, mock_result) do |params|
+      assert_equal 100, params[:amount]
+      assert_equal "usd", params[:currency]
+      assert_equal "spt_test123", params[:shared_payment_granted_token]
+      assert_equal true, params[:confirm]
+      assert_equal ["card", "link"], params[:payment_method_types]
+      refute params.key?(:automatic_payment_methods)
+      assert_equal({"order" => "123"}, params[:metadata])
+      true
+    end
 
     mock_v1 = Struct.new(:payment_intents).new(mock_pi)
     mock_client = Struct.new(:v1).new(mock_v1)
@@ -89,6 +101,26 @@ class TestStripeChargeIntent < Minitest::Test
     end
 
     mock_pi.verify
+  end
+
+  def test_verify_rejects_missing_payment_method_types
+    credential = make_credential(payload: {"spt" => "spt_test123"})
+    request = make_request(payment_method_types: nil)
+
+    err = assert_raises(Mpp::VerificationError) do
+      @intent.verify(credential, request)
+    end
+    assert_match(/paymentMethodTypes/, err.message)
+  end
+
+  def test_verify_rejects_empty_payment_method_types
+    credential = make_credential(payload: {"spt" => "spt_test123"})
+    request = make_request(payment_method_types: [])
+
+    err = assert_raises(Mpp::VerificationError) do
+      @intent.verify(credential, request)
+    end
+    assert_match(/paymentMethodTypes/, err.message)
   end
 
   def test_verify_rejects_failed_payment

--- a/test/mpp/methods/stripe/test_stripe_method.rb
+++ b/test/mpp/methods/stripe/test_stripe_method.rb
@@ -33,7 +33,8 @@ class TestStripeMethod < Minitest::Test
     result = @method.transform_request(request, nil)
 
     assert_equal "acct_test123", result["methodDetails"]["networkId"]
-    assert_equal ["card"], result["methodDetails"]["paymentMethods"]
+    assert_equal ["card"], result["methodDetails"]["paymentMethodTypes"]
+    refute result["methodDetails"].key?("paymentMethods")
     assert_equal({"app" => "myapp"}, result["methodDetails"]["metadata"])
   end
 
@@ -50,22 +51,43 @@ class TestStripeMethod < Minitest::Test
     assert_equal "value", result["methodDetails"]["existing"]
   end
 
-  def test_transform_request_omits_nil_payment_methods
+  def test_requires_payment_methods_allowlist
+    assert_raises(ArgumentError) do
+      Mpp::Methods::Stripe::StripeMethod.new(
+        secret_key: "sk_test_fake",
+        network_id: "acct_test123"
+      )
+    end
+  end
+
+  def test_rejects_empty_payment_methods_allowlist
+    assert_raises(ArgumentError) do
+      Mpp::Methods::Stripe::StripeMethod.new(
+        secret_key: "sk_test_fake",
+        network_id: "acct_test123",
+        payment_methods: []
+      )
+    end
+  end
+
+  def test_transform_request_omits_nil_metadata
     method = Mpp::Methods::Stripe::StripeMethod.new(
       secret_key: "sk_test_fake",
-      network_id: "acct_test123"
+      network_id: "acct_test123",
+      payment_methods: ["card"]
     )
     result = method.transform_request({"amount" => "100"}, nil)
 
     assert_equal "acct_test123", result["methodDetails"]["networkId"]
-    refute result["methodDetails"].key?("paymentMethods")
+    assert_equal ["card"], result["methodDetails"]["paymentMethodTypes"]
     refute result["methodDetails"].key?("metadata")
   end
 
   def test_factory_creates_method_with_charge_intent
     method = Mpp::Methods::Stripe.stripe(
       secret_key: "sk_test_fake",
-      network_id: "acct_test123"
+      network_id: "acct_test123",
+      payment_methods: ["card"]
     )
 
     assert_equal "stripe", method.name
@@ -100,7 +122,7 @@ class TestStripeMethod < Minitest::Test
     assert_equal "usd", request["currency"]
     assert_equal "acct_test123", request["recipient"]
     assert_equal "acct_test123", request["methodDetails"]["networkId"]
-    assert_equal ["card"], request["methodDetails"]["paymentMethods"]
+    assert_equal ["card"], request["methodDetails"]["paymentMethodTypes"]
     assert_equal({"order" => "abc"}, request["methodDetails"]["metadata"])
   end
 end


### PR DESCRIPTION
The Stripe method advertised an allowed-payment-methods list but never enforced it.

- Challenge now uses the spec key `paymentMethodTypes` (was `paymentMethods`)
- `verify` sends `payment_method_types` to Stripe instead of `automatic_payment_methods`, so only allowed methods can charge
- `payment_methods:` is now required (raises `ArgumentError` if missing/empty)