### PR TITLE
fix(tempo): bind proof signatures to realm + wallet (EIP-712 v2)

### DIFF
--- a/lib/mpp/methods/tempo/client_method.rb
+++ b/lib/mpp/methods/tempo/client_method.rb
@@ -92,7 +92,8 @@ module Mpp
             signature = Proof.sign(
               account: @account,
               chain_id: chain_id,
-              challenge_id: challenge.id
+              challenge_id: challenge.id,
+              realm: challenge.realm
             )
 
             return Mpp::Credential.new(

--- a/lib/mpp/methods/tempo/intents.rb
+++ b/lib/mpp/methods/tempo/intents.rb
@@ -294,6 +294,7 @@ module Mpp
             address: source[:address],
             chain_id: resolved_chain_id,
             challenge_id: credential.challenge.id,
+            realm: credential.challenge.realm,
             signature: payload.signature
           )
           raise Mpp::VerificationError, "Proof signature does not match source" unless valid

--- a/lib/mpp/methods/tempo/proof.rb
+++ b/lib/mpp/methods/tempo/proof.rb
@@ -6,16 +6,16 @@ module Mpp
     module Tempo
       # EIP-712 proof credentials for zero-amount challenges.
       #
-      # Domain: { name: "MPP", version: "1", chainId }
-      # Types:  { Proof: [{ name: "challengeId", type: "string" }] }
-      # Message: { challengeId: <challenge.id> }
+      # Domain: { name: "MPP", version: "2", chainId }
+      # Types:  { Proof: [{ name: "challengeId", type: "string" }, { name: "realm", type: "string" }] }
+      # Message: { challengeId: <challenge.id>, realm: <challenge.realm> }
       module Proof
         DOMAIN_NAME = "MPP"
-        DOMAIN_VERSION = "1"
+        DOMAIN_VERSION = "2"
 
         # EIP-712 domain separator type hash
         DOMAIN_TYPE_HASH = "EIP712Domain(string name,string version,uint256 chainId)"
-        PROOF_TYPE_HASH = "Proof(string challengeId)"
+        PROOF_TYPE_HASH = "Proof(string challengeId,string realm)"
 
         module_function
 
@@ -36,35 +36,36 @@ module Mpp
           )
         end
 
-        # Compute the EIP-712 struct hash for Proof(challengeId).
-        def struct_hash(challenge_id)
+        # Compute the EIP-712 struct hash for Proof(challengeId, realm).
+        def struct_hash(challenge_id, realm)
           keccak256(
             abi_encode(
               keccak256(PROOF_TYPE_HASH),
-              keccak256(challenge_id)
+              keccak256(challenge_id),
+              keccak256(realm)
             )
           )
         end
 
         # Compute the full EIP-712 signing hash.
-        def signing_hash(chain_id:, challenge_id:)
+        def signing_hash(chain_id:, challenge_id:, realm:)
           keccak256(
-            "\x19\x01".b + domain_separator(chain_id) + struct_hash(challenge_id)
+            "\x19\x01".b + domain_separator(chain_id) + struct_hash(challenge_id, realm)
           )
         end
 
         # Sign a proof credential (client-side).
-        def sign(account:, chain_id:, challenge_id:)
-          hash = signing_hash(chain_id: chain_id, challenge_id: challenge_id)
+        def sign(account:, chain_id:, challenge_id:, realm:)
+          hash = signing_hash(chain_id: chain_id, challenge_id: challenge_id, realm: realm)
           sig = account.sign_hash(hash)
           "0x#{sig.unpack1("H*")}"
         end
 
         # Verify a proof credential signature (server-side).
-        def verify(address:, chain_id:, challenge_id:, signature:)
+        def verify(address:, chain_id:, challenge_id:, realm:, signature:)
           Kernel.require "eth"
 
-          hash = signing_hash(chain_id: chain_id, challenge_id: challenge_id)
+          hash = signing_hash(chain_id: chain_id, challenge_id: challenge_id, realm: realm)
           sig_bytes = [signature.delete_prefix("0x")].pack("H*")
 
           # Recover the signer address from the signature
@@ -106,7 +107,10 @@ module Mpp
         end
 
         def uint256(value)
-          [value].pack("Q>").rjust(32, "\x00".b)
+          value = Integer(value)
+          raise ArgumentError, "uint256 out of range" if value.negative? || value >= (1 << 256)
+
+          [value.to_s(16).rjust(64, "0")].pack("H*")
         end
 
         def recover_address(hash, sig_bytes)

--- a/test/mpp/methods/tempo/test_proof.rb
+++ b/test/mpp/methods/tempo/test_proof.rb
@@ -1,0 +1,254 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Tests for EIP-712 Tempo proof credentials (zero-amount wallet-ownership proofs).
+# The signed typed data binds both the challenge id AND the server realm, and the
+# wallet is bound via the recovered signer matching the credential source address.
+class TestTempoProof < Minitest::Test
+  Proof = Mpp::Methods::Tempo::Proof
+
+  # Well-known test private keys (deterministic addresses).
+  KEY_A = "0x4c0883a69102937d6231471b5dbb6204fe512961708279f01a7f7e1df7a8b9e2"
+  KEY_B = "0x4646464646464646464646464646464646464646464646464646464646464646"
+
+  CHAIN_ID = 1
+  CHALLENGE_ID = "ch_test_123"
+  REALM = "api.example.com"
+
+  def setup
+    @eth_available = begin
+      require "eth"
+      true
+    rescue LoadError
+      false
+    end
+  end
+
+  def account(key)
+    Mpp::Methods::Tempo::Account.from_key(key)
+  end
+
+  # --- ABI conformance (the create-intent/challenge ABI fixture) ---
+
+  def test_domain_version_is_2
+    assert_equal "2", Proof::DOMAIN_VERSION
+  end
+
+  def test_proof_type_hash_binds_challenge_id_and_realm
+    assert_equal "Proof(string challengeId,string realm)", Proof::PROOF_TYPE_HASH
+  end
+
+  # --- source DID (wallet binding carrier) ---
+
+  def test_source_did_construction
+    source = Proof.source(address: "0xAbC0000000000000000000000000000000000001", chain_id: 8453)
+    assert_equal "did:pkh:eip155:8453:0xAbC0000000000000000000000000000000000001", source
+  end
+
+  def test_parse_source_valid
+    parsed = Proof.parse_source("did:pkh:eip155:1:0xAbC0000000000000000000000000000000000001")
+    assert_equal 1, parsed[:chain_id]
+    assert_equal "0xAbC0000000000000000000000000000000000001", parsed[:address]
+  end
+
+  def test_parse_source_rejects_malformed
+    assert_nil Proof.parse_source("not-a-did")
+    assert_nil Proof.parse_source("did:pkh:eip155:1:0xshort")
+    assert_nil Proof.parse_source("did:pkh:eip155:01:0xAbC0000000000000000000000000000000000001")
+    assert_nil Proof.parse_source("did:pkh:other:1:0xAbC0000000000000000000000000000000000001")
+  end
+
+  # --- sign / verify round trip ---
+
+  def test_sign_verify_round_trip
+    skip "eth gem not available" unless @eth_available
+
+    acct = account(KEY_A)
+    sig = Proof.sign(account: acct, chain_id: CHAIN_ID, challenge_id: CHALLENGE_ID, realm: REALM)
+
+    assert Proof.verify(
+      address: acct.address,
+      chain_id: CHAIN_ID,
+      challenge_id: CHALLENGE_ID,
+      realm: REALM,
+      signature: sig
+    )
+  end
+
+  # --- realm binding ---
+
+  def test_verify_rejects_realm_mismatch
+    skip "eth gem not available" unless @eth_available
+
+    acct = account(KEY_A)
+    sig = Proof.sign(account: acct, chain_id: CHAIN_ID, challenge_id: CHALLENGE_ID, realm: REALM)
+
+    refute Proof.verify(
+      address: acct.address,
+      chain_id: CHAIN_ID,
+      challenge_id: CHALLENGE_ID,
+      realm: "evil.example.com",
+      signature: sig
+    )
+  end
+
+  # --- wallet binding ---
+
+  def test_verify_rejects_wrong_address
+    skip "eth gem not available" unless @eth_available
+
+    acct = account(KEY_A)
+    other = account(KEY_B)
+    sig = Proof.sign(account: acct, chain_id: CHAIN_ID, challenge_id: CHALLENGE_ID, realm: REALM)
+
+    refute Proof.verify(
+      address: other.address,
+      chain_id: CHAIN_ID,
+      challenge_id: CHALLENGE_ID,
+      realm: REALM,
+      signature: sig
+    )
+  end
+
+  # --- challenge id binding ---
+
+  def test_verify_rejects_challenge_id_mismatch
+    skip "eth gem not available" unless @eth_available
+
+    acct = account(KEY_A)
+    sig = Proof.sign(account: acct, chain_id: CHAIN_ID, challenge_id: CHALLENGE_ID, realm: REALM)
+
+    refute Proof.verify(
+      address: acct.address,
+      chain_id: CHAIN_ID,
+      challenge_id: "ch_other",
+      realm: REALM,
+      signature: sig
+    )
+  end
+
+  # --- chain id binding ---
+
+  def test_verify_rejects_chain_id_mismatch
+    skip "eth gem not available" unless @eth_available
+
+    acct = account(KEY_A)
+    sig = Proof.sign(account: acct, chain_id: CHAIN_ID, challenge_id: CHALLENGE_ID, realm: REALM)
+
+    refute Proof.verify(
+      address: acct.address,
+      chain_id: 999,
+      challenge_id: CHALLENGE_ID,
+      realm: REALM,
+      signature: sig
+    )
+  end
+
+  # --- uint256 encoding (domain chainId) regression ---
+
+  def test_uint256_handles_values_above_64_bits
+    skip "eth gem not available" unless @eth_available
+
+    # A chain id larger than 2**64 must not silently truncate; sign/verify must round-trip.
+    big_chain = (1 << 200) + 7
+    acct = account(KEY_A)
+    sig = Proof.sign(account: acct, chain_id: big_chain, challenge_id: CHALLENGE_ID, realm: REALM)
+
+    assert Proof.verify(address: acct.address, chain_id: big_chain, challenge_id: CHALLENGE_ID, realm: REALM, signature: sig)
+    refute Proof.verify(address: acct.address, chain_id: big_chain + 1, challenge_id: CHALLENGE_ID, realm: REALM, signature: sig)
+  end
+
+  # --- server-side verify path (ChargeIntent#verify -> verify_proof) ---
+
+  def server_proof_credential(realm:, signed_realm:, chain_id: 4217, challenge_id: "ch_srv_1")
+    acct = account(KEY_A)
+    sig = Proof.sign(account: acct, chain_id: chain_id, challenge_id: challenge_id, realm: signed_realm)
+    Mpp::Credential.new(
+      challenge: Mpp::ChallengeEcho.new(
+        id: challenge_id, realm: realm, method: "tempo", intent: "charge", request: ""
+      ),
+      payload: {"type" => "proof", "signature" => sig},
+      source: Proof.source(address: acct.address, chain_id: chain_id)
+    )
+  end
+
+  def zero_amount_request
+    {"amount" => "0", "currency" => "0x00", "recipient" => "0x01"}
+  end
+
+  def test_server_verify_proof_round_trip
+    skip "eth gem not available" unless @eth_available
+
+    intent = Mpp::Methods::Tempo::ChargeIntent.new
+    credential = server_proof_credential(realm: REALM, signed_realm: REALM)
+
+    receipt = intent.verify(credential, zero_amount_request)
+    assert_equal "ch_srv_1", receipt.reference
+  end
+
+  def test_server_verify_proof_rejects_realm_mismatch
+    skip "eth gem not available" unless @eth_available
+
+    intent = Mpp::Methods::Tempo::ChargeIntent.new
+    # Signed for a different realm than the challenge echo claims.
+    credential = server_proof_credential(realm: REALM, signed_realm: "evil.example.com")
+
+    err = assert_raises(Mpp::VerificationError) do
+      intent.verify(credential, zero_amount_request)
+    end
+    assert_match(/does not match source/, err.message)
+  end
+
+  def test_server_verify_proof_rejects_nonzero_amount
+    skip "eth gem not available" unless @eth_available
+
+    intent = Mpp::Methods::Tempo::ChargeIntent.new
+    credential = server_proof_credential(realm: REALM, signed_realm: REALM)
+
+    err = assert_raises(Mpp::VerificationError) do
+      intent.verify(credential, {"amount" => "100", "currency" => "0x00", "recipient" => "0x01"})
+    end
+    assert_match(/zero-amount/, err.message)
+  end
+
+  # --- end-to-end through the client method (proves realm wiring) ---
+
+  def test_client_create_credential_proof_mode_binds_realm
+    skip "eth gem not available" unless @eth_available
+
+    acct = account(KEY_A)
+    method = Mpp::Methods::Tempo::TempoMethod.new(account: acct, chain_id: CHAIN_ID)
+
+    challenge = Mpp::Challenge.create(
+      secret_key: "test-secret",
+      realm: REALM,
+      method: "tempo",
+      intent: "charge",
+      request: {"amount" => "0", "currency" => "0x00", "recipient" => "0x01", "methodDetails" => {}},
+      expires: (Time.now.utc + 300).strftime("%Y-%m-%dT%H:%M:%S.%LZ")
+    )
+
+    credential = method.create_credential(challenge, mode: :proof)
+
+    assert_equal "proof", credential.payload["type"]
+    source = Proof.parse_source(credential.source)
+    assert_equal acct.address.downcase, source[:address].downcase
+
+    # Verifies only with the real challenge realm, not a forged one.
+    assert Proof.verify(
+      address: source[:address],
+      chain_id: CHAIN_ID,
+      challenge_id: challenge.id,
+      realm: challenge.realm,
+      signature: credential.payload["signature"]
+    )
+    refute Proof.verify(
+      address: source[:address],
+      chain_id: CHAIN_ID,
+      challenge_id: challenge.id,
+      realm: "evil.example.com",
+      signature: credential.payload["signature"]
+    )
+  end
+end


### PR DESCRIPTION
Direct `ChargeIntent#verify` callers trust the client-supplied realm, so zero-amount Tempo proofs weren't bound to it there (the standard `verify_or_challenge` path was already safe — `challenge.id` is an HMAC over the realm). Adds realm to the proof signature as defense-in-depth and aligns the EIP-712 ABI with the canonical SDKs (mpp-rs, mppx).

- domain version `"1"` → `"2"`
- `Proof(string challengeId)` → `Proof(string challengeId,string realm)`
- client signs / server verifies with the challenge realm
- wallet binding unchanged (signer recovered & compared to the did:pkh source)
- adds `test_proof.rb`

Note: breaking for old v1 proofs