### PR TITLE
feat: validate hash credential source

### DIFF
--- a/lib/mpp/methods/tempo/intents.rb
+++ b/lib/mpp/methods/tempo/intents.rb
@@ -85,6 +85,12 @@ module Mpp
         def parse_hash_credential_source(source, expected_chain_id)
           return nil unless source
 
+          expected_chain_id = begin
+            Integer(expected_chain_id)
+          rescue ArgumentError, TypeError
+            raise Mpp::VerificationError, "Hash credential source is invalid"
+          end
+
           parsed = Proof.parse_source(source)
           unless parsed && parsed[:chain_id] == expected_chain_id
             raise Mpp::VerificationError, "Hash credential source is invalid"
@@ -110,9 +116,11 @@ module Mpp
           raise Mpp::VerificationError, "Transaction reverted" unless result["status"] == "0x1"
 
           # Use the source address if present, otherwise the receipt sender.
+          # The sender override only applies when a source was declared; without
+          # one, the legacy receipt["from"] match must hold unconditionally.
           expected_sender = source_address || result["from"]
           matched_logs = match_transfer_logs(result, request, expected_sender: expected_sender,
-            source: credential.source, validate_sender: @validate_sender)
+            source: credential.source, validate_sender: source_address ? @validate_sender : nil)
           unless matched_logs.any?
             raise Mpp::VerificationError,
               "Transaction must contain a Transfer log matching request parameters"

--- a/lib/mpp/methods/tempo/intents.rb
+++ b/lib/mpp/methods/tempo/intents.rb
@@ -20,12 +20,13 @@ module Mpp
         attr_reader :name
         attr_accessor :rpc_url
 
-        def initialize(chain_id: nil, rpc_url: nil, timeout: 30, store: nil)
+        def initialize(chain_id: nil, rpc_url: nil, timeout: 30, store: nil, validate_sender: nil)
           @name = "charge"
           @rpc_url = rpc_url || (chain_id ? Defaults.rpc_url_for_chain(chain_id) : nil)
           @_method = nil
           @timeout = timeout
           @store = store
+          @validate_sender = validate_sender
         end
 
         def fee_payer
@@ -79,7 +80,23 @@ module Mpp
           @rpc_url
         end
 
+        # Parse a hash credential source: nil if absent, the address for a
+        # did:pkh:eip155 DID matching expected_chain_id, else raises.
+        def parse_hash_credential_source(source, expected_chain_id)
+          return nil unless source
+
+          parsed = Proof.parse_source(source)
+          unless parsed && parsed[:chain_id] == expected_chain_id
+            raise Mpp::VerificationError, "Hash credential source is invalid"
+          end
+
+          parsed[:address]
+        end
+
         def verify_hash(payload, request, credential:)
+          # Validate the source before reserving the hash.
+          source_address = parse_hash_credential_source(credential.source, request.method_details.chain_id)
+
           if @store
             store_key = "mpp:charge:#{payload.hash.downcase}"
             raise Mpp::VerificationError, "Transaction hash already used" unless @store.put_if_absent(store_key,
@@ -91,7 +108,11 @@ module Mpp
 
           raise Mpp::VerificationError, "Transaction not found" unless result
           raise Mpp::VerificationError, "Transaction reverted" unless result["status"] == "0x1"
-          matched_logs = match_transfer_logs(result, request, expected_sender: result["from"])
+
+          # Use the source address if present, otherwise the receipt sender.
+          expected_sender = source_address || result["from"]
+          matched_logs = match_transfer_logs(result, request, expected_sender: expected_sender,
+            source: credential.source, validate_sender: @validate_sender)
           unless matched_logs.any?
             raise Mpp::VerificationError,
               "Transaction must contain a Transfer log matching request parameters"
@@ -146,7 +167,7 @@ module Mpp
           match_transfer_logs(receipt, request, expected_sender: expected_sender).any?
         end
 
-        def match_transfer_logs(receipt, request, expected_sender: nil)
+        def match_transfer_logs(receipt, request, expected_sender: nil, source: nil, validate_sender: nil)
           expected_memo = request.method_details.memo
           matched_logs = []
 
@@ -160,40 +181,57 @@ module Mpp
             to_address = "0x#{topics[2][-40..]}"
 
             next unless to_address.downcase == request.recipient.downcase
-            next if expected_sender && from_address.downcase != expected_sender.downcase
 
-            if expected_memo
-              next unless topics[0] == TRANSFER_WITH_MEMO_TOPIC
-              next if topics.length < 4
-
-              data = log.fetch("data", "0x")
-              next if data.length < 66
-
-              amount = data[2, 64].to_i(16)
-              memo = topics[3]
-              memo_clean = expected_memo.downcase
-              memo_clean = "0x#{memo_clean}" unless memo_clean.start_with?("0x")
-              if amount == Integer(request.amount) && memo.downcase == memo_clean
-                matched_logs << {kind: :memo, memo: memo}
-              end
-            else
-              case topics[0]
-              when TRANSFER_WITH_MEMO_TOPIC
+            matched =
+              if expected_memo
+                next unless topics[0] == TRANSFER_WITH_MEMO_TOPIC
                 next if topics.length < 4
 
                 data = log.fetch("data", "0x")
                 next if data.length < 66
 
                 amount = data[2, 64].to_i(16)
-                matched_logs << {kind: :memo, memo: topics[3]} if amount == Integer(request.amount)
-              when TRANSFER_TOPIC
-                data = log.fetch("data", "0x")
-                next if data.length < 66
+                memo = topics[3]
+                memo_clean = expected_memo.downcase
+                memo_clean = "0x#{memo_clean}" unless memo_clean.start_with?("0x")
+                next unless amount == Integer(request.amount) && memo.downcase == memo_clean
 
-                amount = data.delete_prefix("0x").to_i(16)
-                matched_logs << {kind: :transfer} if amount == Integer(request.amount)
+                {kind: :memo, memo: memo}
+              else
+                case topics[0]
+                when TRANSFER_WITH_MEMO_TOPIC
+                  next if topics.length < 4
+
+                  data = log.fetch("data", "0x")
+                  next if data.length < 66
+
+                  amount = data[2, 64].to_i(16)
+                  next unless amount == Integer(request.amount)
+
+                  {kind: :memo, memo: topics[3]}
+                when TRANSFER_TOPIC
+                  data = log.fetch("data", "0x")
+                  next if data.length < 66
+
+                  amount = data.delete_prefix("0x").to_i(16)
+                  next unless amount == Integer(request.amount)
+
+                  {kind: :transfer}
+                end
               end
+
+            next unless matched
+
+            # On a sender mismatch, validate_sender may authorize the log.
+            if expected_sender && from_address.downcase != expected_sender.downcase
+              next unless validate_sender&.call(
+                expected_sender: expected_sender,
+                sender: from_address,
+                source: source
+              )
             end
+
+            matched_logs << matched
           end
 
           matched_logs.sort_by { |log| (log[:kind] == :memo) ? 0 : 1 }

--- a/test/mpp/methods/tempo/test_charge_intent.rb
+++ b/test/mpp/methods/tempo/test_charge_intent.rb
@@ -8,6 +8,9 @@ class TestTempoChargeIntent < Minitest::Test
   REALM = "api.example.com"
   RECIPIENT = "0x1234567890abcdef1234567890abcdef12345678"
   SENDER = "0x0000000000000000000000000000000000000001"
+  CHAIN_ID = Mpp::Methods::Tempo::Defaults::CHAIN_ID
+  SOURCE_ADDR = "0x00000000000000000000000000000000000000aa"
+  RELAYER = "0x00000000000000000000000000000000000000bb"
 
   def setup
     @intent = Mpp::Methods::Tempo::ChargeIntent.new(rpc_url: "https://rpc.example.test")
@@ -116,7 +119,177 @@ class TestTempoChargeIntent < Minitest::Test
     assert_match(/already been used/, error.message)
   end
 
+  def test_parse_hash_credential_source_absent_is_nil
+    assert_nil @intent.send(:parse_hash_credential_source, nil, CHAIN_ID)
+  end
+
+  def test_parse_hash_credential_source_valid_returns_address
+    source = did_pkh(CHAIN_ID, SOURCE_ADDR)
+    assert_equal SOURCE_ADDR, @intent.send(:parse_hash_credential_source, source, CHAIN_ID)
+  end
+
+  def test_parse_hash_credential_source_chain_mismatch_rejected
+    error = assert_raises(Mpp::VerificationError) do
+      @intent.send(:parse_hash_credential_source, did_pkh(1, SOURCE_ADDR), CHAIN_ID)
+    end
+    assert_match(/Hash credential source is invalid/, error.message)
+  end
+
+  def test_parse_hash_credential_source_rejects_malformed_variants
+    [
+      "not-a-valid-did",
+      "did:pkh:solana:#{CHAIN_ID}:#{SOURCE_ADDR}",
+      "did:pkh:eip155:04217:#{SOURCE_ADDR}",
+      "did:pkh:eip155:not-a-number:#{SOURCE_ADDR}",
+      "did:pkh:eip155:#{CHAIN_ID}:extra:#{SOURCE_ADDR}",
+      "did:pkh:eip155:#{CHAIN_ID}:not-an-address"
+    ].each do |source|
+      error = assert_raises(Mpp::VerificationError, "case: #{source}") do
+        @intent.send(:parse_hash_credential_source, source, CHAIN_ID)
+      end
+      assert_match(/Hash credential source is invalid/, error.message, "case: #{source}")
+    end
+  end
+
+  def test_hash_accepts_source_matching_transfer_sender
+    receipt = receipt([transfer_log(memo: bound_memo, from: SOURCE_ADDR)])
+    result = verify_hash_source(receipt, source: did_pkh(CHAIN_ID, SOURCE_ADDR))
+    assert_equal HASH, result.reference
+  end
+
+  def test_hash_accepts_source_when_receipt_sender_differs
+    # Relayer submitted the tx (receipt.from = RELAYER) but the transfer is
+    # from the declared source.
+    receipt = {"status" => "0x1", "from" => RELAYER,
+               "logs" => [transfer_log(memo: bound_memo, from: SOURCE_ADDR)]}
+    result = verify_hash_source(receipt, source: did_pkh(CHAIN_ID, SOURCE_ADDR))
+    assert_equal HASH, result.reference
+  end
+
+  def test_hash_rejects_source_differing_from_transfer_sender
+    receipt = receipt([transfer_log(memo: bound_memo, from: RELAYER)])
+    error = assert_raises(Mpp::VerificationError) do
+      verify_hash_source(receipt, source: did_pkh(CHAIN_ID, SOURCE_ADDR))
+    end
+    assert_match(/must contain a Transfer log/, error.message)
+  end
+
+  def test_hash_validate_sender_override_allows_mismatch
+    seen = {}
+    intent = Mpp::Methods::Tempo::ChargeIntent.new(
+      rpc_url: "https://rpc.example.test",
+      validate_sender: ->(expected_sender:, sender:, source:) {
+        seen = {expected_sender: expected_sender, sender: sender, source: source}
+        true
+      }
+    )
+    receipt = receipt([transfer_log(memo: bound_memo, from: RELAYER)])
+    result = verify_hash_source(receipt, source: did_pkh(CHAIN_ID, SOURCE_ADDR), intent: intent)
+
+    assert_equal HASH, result.reference
+    assert_equal SOURCE_ADDR.downcase, seen[:expected_sender].downcase
+    assert_equal RELAYER.downcase, seen[:sender].downcase
+    assert_equal did_pkh(CHAIN_ID, SOURCE_ADDR), seen[:source]
+  end
+
+  def test_hash_validate_sender_returning_false_rejects
+    intent = Mpp::Methods::Tempo::ChargeIntent.new(
+      rpc_url: "https://rpc.example.test",
+      validate_sender: ->(expected_sender:, sender:, source:) { false }
+    )
+    receipt = receipt([transfer_log(memo: bound_memo, from: RELAYER)])
+    error = assert_raises(Mpp::VerificationError) do
+      verify_hash_source(receipt, source: did_pkh(CHAIN_ID, SOURCE_ADDR), intent: intent)
+    end
+    assert_match(/must contain a Transfer log/, error.message)
+  end
+
+  def test_hash_rejects_source_from_different_chain
+    receipt = receipt([transfer_log(memo: bound_memo, from: SOURCE_ADDR)])
+    error = assert_raises(Mpp::VerificationError) do
+      verify_hash_source(receipt, source: did_pkh(1, SOURCE_ADDR))
+    end
+    assert_match(/Hash credential source is invalid/, error.message)
+  end
+
+  def test_hash_validate_sender_not_called_when_sender_matches
+    intent = Mpp::Methods::Tempo::ChargeIntent.new(
+      rpc_url: "https://rpc.example.test",
+      validate_sender: ->(expected_sender:, sender:, source:) { raise "must not be called" }
+    )
+    receipt = receipt([transfer_log(memo: bound_memo, from: SOURCE_ADDR)])
+    result = verify_hash_source(receipt, source: did_pkh(CHAIN_ID, SOURCE_ADDR), intent: intent)
+    assert_equal HASH, result.reference
+  end
+
+  def test_hash_validate_sender_not_called_for_non_candidate_logs
+    explicit_memo = "0x#{"ab" * 32}"
+    other_memo = "0x#{"cd" * 32}"
+    intent = Mpp::Methods::Tempo::ChargeIntent.new(
+      rpc_url: "https://rpc.example.test",
+      validate_sender: ->(expected_sender:, sender:, source:) { raise "must not be called" }
+    )
+    # First log has a wrong sender and a non-matching memo (non-candidate);
+    # second log matches fully, so the callback is never reached.
+    receipt = receipt([
+      transfer_log(memo: other_memo, from: RELAYER),
+      transfer_log(memo: explicit_memo, from: SOURCE_ADDR)
+    ])
+    credential = Mpp::Credential.new(
+      challenge: Mpp::ChallengeEcho.new(id: "challenge-123", realm: REALM, method: "tempo",
+        intent: "charge", request: ""),
+      payload: {"type" => "hash", "hash" => HASH},
+      source: did_pkh(CHAIN_ID, SOURCE_ADDR)
+    )
+    result = Mpp::Methods::Tempo::Rpc.stub(:call, ->(_rpc_url, _method, _params) { receipt }) do
+      intent.verify(credential, request_hash(memo: explicit_memo))
+    end
+    assert_equal HASH, result.reference
+  end
+
+  def test_hash_malformed_source_does_not_consume_hash
+    store = Mpp::MemoryStore.new
+    intent = Mpp::Methods::Tempo::ChargeIntent.new(rpc_url: "https://rpc.example.test", store: store)
+    receipt = receipt([transfer_log(memo: bound_memo, from: SOURCE_ADDR)])
+
+    # Malformed source is rejected before the hash is reserved.
+    assert_raises(Mpp::VerificationError) do
+      verify_hash_source(receipt, source: "not-a-valid-did", intent: intent)
+    end
+    assert_nil store.get("mpp:charge:#{HASH.downcase}")
+
+    # A valid retry then succeeds.
+    result = verify_hash_source(receipt, source: did_pkh(CHAIN_ID, SOURCE_ADDR), intent: intent)
+    assert_equal HASH, result.reference
+  end
+
   private
+
+  def did_pkh(chain_id, address)
+    "did:pkh:eip155:#{chain_id}:#{address}"
+  end
+
+  def bound_memo
+    Mpp::Methods::Tempo::Attribution.encode(server_id: REALM, challenge_id: "challenge-123")
+  end
+
+  def verify_hash_source(receipt, source:, intent: @intent, challenge_id: "challenge-123")
+    credential = Mpp::Credential.new(
+      challenge: Mpp::ChallengeEcho.new(
+        id: challenge_id,
+        realm: REALM,
+        method: "tempo",
+        intent: "charge",
+        request: ""
+      ),
+      payload: {"type" => "hash", "hash" => HASH},
+      source: source
+    )
+
+    Mpp::Methods::Tempo::Rpc.stub(:call, ->(_rpc_url, _method, _params) { receipt }) do
+      intent.verify(credential, request_hash)
+    end
+  end
 
   def verify_hash(receipt, challenge_id:, memo: nil)
     credential = Mpp::Credential.new(
@@ -153,10 +326,10 @@ class TestTempoChargeIntent < Minitest::Test
     {"status" => "0x1", "from" => SENDER, "logs" => logs}
   end
 
-  def transfer_log(memo: nil)
+  def transfer_log(memo: nil, from: SENDER)
     topics = [
       memo ? Mpp::Methods::Tempo::TRANSFER_WITH_MEMO_TOPIC : Mpp::Methods::Tempo::TRANSFER_TOPIC,
-      topic_address(SENDER),
+      topic_address(from),
       topic_address(RECIPIENT)
     ]
     topics << memo if memo

--- a/test/mpp/methods/tempo/test_charge_intent.rb
+++ b/test/mpp/methods/tempo/test_charge_intent.rb
@@ -135,6 +135,18 @@ class TestTempoChargeIntent < Minitest::Test
     assert_match(/Hash credential source is invalid/, error.message)
   end
 
+  def test_parse_hash_credential_source_accepts_string_chain_id
+    source = did_pkh(CHAIN_ID, SOURCE_ADDR)
+    assert_equal SOURCE_ADDR, @intent.send(:parse_hash_credential_source, source, CHAIN_ID.to_s)
+  end
+
+  def test_parse_hash_credential_source_rejects_non_numeric_chain_id
+    error = assert_raises(Mpp::VerificationError) do
+      @intent.send(:parse_hash_credential_source, did_pkh(CHAIN_ID, SOURCE_ADDR), "not-a-number")
+    end
+    assert_match(/Hash credential source is invalid/, error.message)
+  end
+
   def test_parse_hash_credential_source_rejects_malformed_variants
     [
       "not-a-valid-did",
@@ -200,6 +212,22 @@ class TestTempoChargeIntent < Minitest::Test
     receipt = receipt([transfer_log(memo: bound_memo, from: RELAYER)])
     error = assert_raises(Mpp::VerificationError) do
       verify_hash_source(receipt, source: did_pkh(CHAIN_ID, SOURCE_ADDR), intent: intent)
+    end
+    assert_match(/must contain a Transfer log/, error.message)
+  end
+
+  def test_hash_no_source_ignores_validate_sender_override
+    # With no declared source the override must not apply: a transfer whose
+    # sender differs from receipt["from"] must still be rejected even if the
+    # callback would authorize it.
+    intent = Mpp::Methods::Tempo::ChargeIntent.new(
+      rpc_url: "https://rpc.example.test",
+      validate_sender: ->(expected_sender:, sender:, source:) { true }
+    )
+    # receipt["from"] is SENDER, but the transfer log is from RELAYER.
+    receipt = receipt([transfer_log(memo: bound_memo, from: RELAYER)])
+    error = assert_raises(Mpp::VerificationError) do
+      verify_hash_source(receipt, source: nil, intent: intent)
     end
     assert_match(/must contain a Transfer log/, error.message)
   end


### PR DESCRIPTION
Validates the `source` field on Tempo hash credentials during server-side verification. Transfers must originate from the declared `did:pkh` source address (falling back to the on-chain receipt sender when no source is given), and malformed or wrong-chain sources are rejected. Adds a `validate_sender` option on `ChargeIntent` to authorize smart-account / relayer flows where the transfer sender differs from the source.

Part of OSS-323