### PR TITLE
feat: add server body digest and route scope conformance

### DIFF
--- a/lib/mpp/body_digest.rb
+++ b/lib/mpp/body_digest.rb
@@ -21,7 +21,7 @@ module Mpp
       when String
         # use as-is
       end
-      body = body.encode(Encoding::UTF_8) if body.is_a?(String)
+      body = body.b if body.is_a?(String)
       digest = OpenSSL::Digest::SHA256.digest(body)
       encoded = Base64.strict_encode64(digest)
       "sha-256=#{encoded}"

--- a/lib/mpp/server/middleware.rb
+++ b/lib/mpp/server/middleware.rb
@@ -28,11 +28,14 @@ module Mpp
       sig { params(env: T.untyped).returns(T::Array[T.untyped]) }
       def call(env)
         authorization = env["HTTP_AUTHORIZATION"]
-        request_body = read_request_body(env)
+        body_capture = capture_request_body(env)
         status, headers, body = @app.call(env)
 
         charge_opts = env["mpp.charge"]
         return [status, headers, body] unless charge_opts
+
+        request_body = body_capture&.materialize
+        env["rack.input"] = StringIO.new(request_body || "") if body_capture
 
         amount = charge_opts[:amount]
         opts = charge_opts.except(:amount, :body)
@@ -69,14 +72,14 @@ module Mpp
 
       private
 
-      sig { params(env: T.untyped).returns(T.nilable(String)) }
-      def read_request_body(env)
+      sig { params(env: T.untyped).returns(T.nilable(RackInputCapture)) }
+      def capture_request_body(env)
         input = env["rack.input"]
         return nil unless input&.respond_to?(:read)
 
-        body = T.let(input.read || "", String)
-        env["rack.input"] = StringIO.new(body)
-        body.empty? ? nil : body
+        capture = RackInputCapture.new(input)
+        env["rack.input"] = capture
+        capture
       end
 
       sig { params(env: T.untyped).returns(T::Hash[String, String]) }
@@ -90,6 +93,57 @@ module Mpp
         query = env["QUERY_STRING"]
         scope["query"] = query if query.is_a?(String) && !query.empty?
         scope
+      end
+
+      class RackInputCapture
+        extend T::Sig
+
+        sig { params(input: T.untyped).void }
+        def initialize(input)
+          @input = T.let(input, T.untyped)
+          @buffer = T.let(+"".b, String)
+        end
+
+        sig { params(args: T.untyped).returns(T.untyped) }
+        def read(*args)
+          chunk = @input.read(*args)
+          @buffer << chunk.b if chunk && !chunk.empty?
+          chunk
+        end
+
+        sig { params(args: T.untyped).returns(T.untyped) }
+        def gets(*args)
+          chunk = @input.gets(*args)
+          @buffer << chunk.b if chunk && !chunk.empty?
+          chunk
+        end
+
+        sig { params(block: T.nilable(T.proc.params(chunk: T.untyped).void)).returns(T.untyped) }
+        def each(&block)
+          return enum_for(:each) unless block
+
+          @input.each do |chunk|
+            @buffer << chunk.b if chunk && !chunk.empty?
+            block.call(chunk)
+          end
+        end
+
+        sig { returns(T.untyped) }
+        def rewind
+          @input.rewind if @input.respond_to?(:rewind)
+          @buffer = +"".b
+        end
+
+        sig { returns(T.untyped) }
+        def close
+          @input.close if @input.respond_to?(:close)
+        end
+
+        sig { returns(T.nilable(String)) }
+        def materialize
+          read
+          @buffer.empty? ? nil : @buffer.dup
+        end
       end
     end
   end

--- a/lib/mpp/server/middleware.rb
+++ b/lib/mpp/server/middleware.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "stringio"
+
 module Mpp
   module Server
     # Rack middleware that intercepts requests requiring payment.
@@ -72,7 +74,7 @@ module Mpp
         return nil unless input&.respond_to?(:read)
 
         body = T.let(input.read || "", String)
-        input.rewind if input.respond_to?(:rewind)
+        env["rack.input"] = StringIO.new(body)
         body.empty? ? nil : body
       end
     end

--- a/lib/mpp/server/middleware.rb
+++ b/lib/mpp/server/middleware.rb
@@ -83,6 +83,7 @@ module Mpp
       def mppx_scope(env)
         scope = T.let({}, T::Hash[String, String])
         route = env["action_dispatch.route_uri_pattern"] || env["sinatra.route"] || env["roda.route"]
+        route = route.split(" ", 2).last if route.is_a?(String) && route.match?(/\A[A-Z]+\s+/)
         scope["route"] = route if route.is_a?(String) && !route.empty?
         path = env["PATH_INFO"]
         scope["resource"] = path if path.is_a?(String) && !path.empty?

--- a/lib/mpp/server/middleware.rb
+++ b/lib/mpp/server/middleware.rb
@@ -36,6 +36,7 @@ module Mpp
 
         amount = charge_opts[:amount]
         opts = charge_opts.except(:amount, :body)
+        opts[:mppx_scope] ||= mppx_scope(env)
 
         result = @handler.charge(authorization, amount, **opts, body: request_body)
 
@@ -76,6 +77,18 @@ module Mpp
         body = T.let(input.read || "", String)
         env["rack.input"] = StringIO.new(body)
         body.empty? ? nil : body
+      end
+
+      sig { params(env: T.untyped).returns(T::Hash[String, String]) }
+      def mppx_scope(env)
+        scope = T.let({}, T::Hash[String, String])
+        route = env["action_dispatch.route_uri_pattern"] || env["sinatra.route"] || env["roda.route"]
+        scope["route"] = route if route.is_a?(String) && !route.empty?
+        path = env["PATH_INFO"]
+        scope["resource"] = path if path.is_a?(String) && !path.empty?
+        query = env["QUERY_STRING"]
+        scope["query"] = query if query.is_a?(String) && !query.empty?
+        scope
       end
     end
   end

--- a/lib/mpp/server/middleware.rb
+++ b/lib/mpp/server/middleware.rb
@@ -26,15 +26,16 @@ module Mpp
       sig { params(env: T.untyped).returns(T::Array[T.untyped]) }
       def call(env)
         authorization = env["HTTP_AUTHORIZATION"]
+        request_body = read_request_body(env)
         status, headers, body = @app.call(env)
 
         charge_opts = env["mpp.charge"]
         return [status, headers, body] unless charge_opts
 
         amount = charge_opts[:amount]
-        opts = charge_opts.except(:amount)
+        opts = charge_opts.except(:amount, :body)
 
-        result = @handler.charge(authorization, amount, **opts)
+        result = @handler.charge(authorization, amount, **opts, body: request_body)
 
         if result.is_a?(Mpp::Challenge)
           resp = Mpp::Server::Decorator.make_challenge_response(result, @handler.realm)
@@ -61,6 +62,18 @@ module Mpp
           .compact
           .reject(&:empty?)
           .join(", ")
+      end
+
+      private
+
+      sig { params(env: T.untyped).returns(T.nilable(String)) }
+      def read_request_body(env)
+        input = env["rack.input"]
+        return nil unless input&.respond_to?(:read)
+
+        body = T.let(input.read || "", String)
+        input.rewind if input.respond_to?(:rewind)
+        body.empty? ? nil : body
       end
     end
   end

--- a/lib/mpp/server/mpp_handler.rb
+++ b/lib/mpp/server/mpp_handler.rb
@@ -63,9 +63,9 @@ module Mpp
       end
 
       # Handle a charge intent.
-      sig { params(authorization: T.nilable(String), amount: String, currency: T.nilable(String), recipient: T.nilable(String), expires: T.nilable(String), description: T.nilable(String), memo: T.nilable(String), fee_payer: T::Boolean, chain_id: T.nilable(Integer), extra: T.nilable(T::Hash[String, String])).returns(T.untyped) }
+      sig { params(authorization: T.nilable(String), amount: String, currency: T.nilable(String), recipient: T.nilable(String), expires: T.nilable(String), description: T.nilable(String), memo: T.nilable(String), fee_payer: T::Boolean, chain_id: T.nilable(Integer), extra: T.nilable(T::Hash[String, String]), body: T.untyped).returns(T.untyped) }
       def charge(authorization, amount, currency: nil, recipient: nil, expires: nil,
-        description: nil, memo: nil, fee_payer: false, chain_id: nil, extra: nil)
+        description: nil, memo: nil, fee_payer: false, chain_id: nil, extra: nil, body: nil)
         intent = @method.intents["charge"]
         raise ArgumentError, "Method #{@method.name} does not support charge intent" unless intent
 
@@ -112,7 +112,8 @@ module Mpp
           method: @method.name,
           description: description,
           expires: expires,
-          events: @events
+          events: @events,
+          body: body
         )
       end
     end

--- a/lib/mpp/server/mpp_handler.rb
+++ b/lib/mpp/server/mpp_handler.rb
@@ -63,9 +63,9 @@ module Mpp
       end
 
       # Handle a charge intent.
-      sig { params(authorization: T.nilable(String), amount: String, currency: T.nilable(String), recipient: T.nilable(String), expires: T.nilable(String), description: T.nilable(String), memo: T.nilable(String), fee_payer: T::Boolean, chain_id: T.nilable(Integer), extra: T.nilable(T::Hash[String, String]), body: T.untyped).returns(T.untyped) }
+      sig { params(authorization: T.nilable(String), amount: String, currency: T.nilable(String), recipient: T.nilable(String), expires: T.nilable(String), description: T.nilable(String), memo: T.nilable(String), fee_payer: T::Boolean, chain_id: T.nilable(Integer), extra: T.nilable(T::Hash[String, String]), mppx_scope: T.nilable(T::Hash[String, String]), body: T.untyped).returns(T.untyped) }
       def charge(authorization, amount, currency: nil, recipient: nil, expires: nil,
-        description: nil, memo: nil, fee_payer: false, chain_id: nil, extra: nil, body: nil)
+        description: nil, memo: nil, fee_payer: false, chain_id: nil, extra: nil, mppx_scope: nil, body: nil)
         intent = @method.intents["charge"]
         raise ArgumentError, "Method #{@method.name} does not support charge intent" unless intent
 
@@ -88,6 +88,12 @@ module Mpp
             raise ArgumentError, "extra must be a dict[str, str]" unless k.is_a?(String) && v.is_a?(String)
           end
           request["extra"] = extra
+        end
+        if mppx_scope
+          mppx_scope.each do |k, v|
+            raise ArgumentError, "mppx_scope must be a dict[str, str]" unless k.is_a?(String) && v.is_a?(String)
+          end
+          request["_mppx_scope"] = mppx_scope
         end
 
         resolved_chain_id = chain_id

--- a/lib/mpp/server/verify.rb
+++ b/lib/mpp/server/verify.rb
@@ -15,9 +15,9 @@ module Mpp
       # Verify a payment credential or generate a new challenge.
       #
       # Returns Challenge (payment required) or [Credential, Receipt] (verified).
-      sig { params(authorization: T.nilable(String), intent: T.untyped, request: T::Hash[String, T.untyped], realm: String, secret_key: String, method: T.nilable(String), description: T.nilable(String), meta: T.nilable(T::Hash[String, T.untyped]), expires: T.nilable(String), events: T.nilable(Mpp::Events::Dispatcher)).returns(T.untyped) }
+      sig { params(authorization: T.nilable(String), intent: T.untyped, request: T::Hash[String, T.untyped], realm: String, secret_key: String, method: T.nilable(String), description: T.nilable(String), meta: T.nilable(T::Hash[String, T.untyped]), expires: T.nilable(String), events: T.nilable(Mpp::Events::Dispatcher), body: T.untyped).returns(T.untyped) }
       def verify_or_challenge(authorization:, intent:, request:, realm:, secret_key:,
-        method: nil, description: nil, meta: nil, expires: nil, events: nil)
+        method: nil, description: nil, meta: nil, expires: nil, events: nil, body: nil)
         method_name = method || "tempo"
         request = Mpp::Units.transform_units(request)
         dispatcher = events
@@ -25,7 +25,7 @@ module Mpp
         method_context = events_enabled ? {name: method_name, intent: intent.name} : nil
 
         new_challenge = Kernel.lambda { |credential = nil, error = nil, submitted_challenge = nil|
-          challenge = create_challenge(method_name, intent.name, request, realm, secret_key, description, meta, expires)
+          challenge = create_challenge(method_name, intent.name, request, realm, secret_key, description, meta, expires, body)
           if error && dispatcher&.has_handlers?(Mpp::Events::PAYMENT_FAILED)
             emit_payment_failed(
               dispatcher: dispatcher,
@@ -115,6 +115,14 @@ module Mpp
           )
         end
 
+        unless body_digest_matches?(echo, body)
+          return new_challenge.call(
+            credential,
+            Mpp::InvalidChallengeError.new(challenge_id: echo.id, reason: "body digest mismatch"),
+            echo
+          )
+        end
+
         # Verify echoed request parameters match endpoint's expected request
         request.each do |key, value|
           unless echo_request[key] == value
@@ -177,15 +185,16 @@ module Mpp
         [credential, receipt]
       end
 
-      sig { params(method: String, intent_name: String, request: T::Hash[String, T.untyped], realm: String, secret_key: String, description: T.nilable(String), meta: T.nilable(T::Hash[String, T.untyped]), expires: T.nilable(String)).returns(Mpp::Challenge) }
+      sig { params(method: String, intent_name: String, request: T::Hash[String, T.untyped], realm: String, secret_key: String, description: T.nilable(String), meta: T.nilable(T::Hash[String, T.untyped]), expires: T.nilable(String), body: T.untyped).returns(Mpp::Challenge) }
       def create_challenge(method, intent_name, request, realm, secret_key,
-        description = nil, meta = nil, expires = nil)
+        description = nil, meta = nil, expires = nil, body = nil)
         expires = nil if expires && !expires.is_a?(String)
 
         if expires.nil?
           expires_dt = Time.now.utc + (DEFAULT_EXPIRES_MINUTES * 60)
           expires = expires_dt.strftime("%Y-%m-%dT%H:%M:%S.%LZ")
         end
+        digest = body.nil? ? nil : Mpp::BodyDigest.compute(body)
 
         Mpp::Challenge.create(
           secret_key: secret_key,
@@ -194,9 +203,20 @@ module Mpp
           intent: intent_name,
           request: request,
           expires: expires,
+          digest: digest,
           description: description,
           meta: meta
         )
+      end
+
+      sig { params(echo: Mpp::ChallengeEcho, body: T.untyped).returns(T::Boolean) }
+      def body_digest_matches?(echo, body)
+        if body.nil?
+          return echo.digest.nil?
+        end
+        return false unless echo.digest
+
+        Mpp::BodyDigest.verify(T.must(echo.digest), body)
       end
 
       sig { params(header: String).returns(T.nilable(String)) }

--- a/test/mpp/test_body_digest.rb
+++ b/test/mpp/test_body_digest.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "base64"
+require "openssl"
 
 class TestBodyDigest < Minitest::Test
   def test_compute_empty_string
@@ -46,5 +48,12 @@ class TestBodyDigest < Minitest::Test
     d2 = Mpp::BodyDigest.compute({"a" => "1", "b" => "2"})
 
     assert_equal d1, d2
+  end
+
+  def test_compute_uses_raw_binary_bytes
+    body = "{\"q\":\"café\"}".b
+    expected = Base64.strict_encode64(OpenSSL::Digest::SHA256.digest(body))
+
+    assert_equal "sha-256=#{expected}", Mpp::BodyDigest.compute(body)
   end
 end

--- a/test/mpp/test_middleware.rb
+++ b/test/mpp/test_middleware.rb
@@ -39,7 +39,7 @@ class TestMiddleware < Minitest::Test
   def test_attaches_receipt_on_successful_payment
     # Build a valid credential from a challenge
     handler = mock_handler
-    challenge = handler.charge(nil, "1.00")
+    challenge = handler.charge(nil, "1.00", mppx_scope: {"resource" => "/resource"})
     assert_instance_of Mpp::Challenge, challenge
 
     # Build a valid credential
@@ -64,6 +64,46 @@ class TestMiddleware < Minitest::Test
     assert_equal "no-store", headers["Cache-Control"]
     assert_vary_authorization headers
     assert_equal ["OK"], body
+  end
+
+  def test_rejects_paid_retry_with_different_auto_route_scope
+    handler = mock_handler
+    app = lambda { |env|
+      env["mpp.charge"] = {amount: "1.00"}
+      [200, {}, ["OK"]]
+    }
+    middleware = Mpp::Server::Middleware.new(app, handler: handler)
+
+    status, headers, _body = middleware.call(
+      minimal_env.merge(
+        "PATH_INFO" => "/paid/one",
+        "QUERY_STRING" => "view=full",
+        "action_dispatch.route_uri_pattern" => "/paid/:id"
+      )
+    )
+    assert_equal 402, status
+
+    challenge = Mpp::Challenge.from_www_authenticate(headers["WWW-Authenticate"])
+    assert_equal(
+      {"route" => "/paid/:id", "resource" => "/paid/one", "query" => "view=full"},
+      challenge.request["_mppx_scope"]
+    )
+    credential = Mpp::Credential.new(
+      challenge: challenge.to_echo,
+      payload: {"type" => "test", "data" => "ok"}
+    )
+
+    status, headers, _body = middleware.call(
+      minimal_env.merge(
+        "HTTP_AUTHORIZATION" => credential.to_authorization,
+        "PATH_INFO" => "/paid/two",
+        "QUERY_STRING" => "view=full",
+        "action_dispatch.route_uri_pattern" => "/paid/:id"
+      )
+    )
+
+    assert_equal 402, status
+    refute headers.key?("Payment-Receipt")
   end
 
   def test_rejects_paid_retry_with_tampered_body_digest

--- a/test/mpp/test_middleware.rb
+++ b/test/mpp/test_middleware.rb
@@ -106,6 +106,30 @@ class TestMiddleware < Minitest::Test
     refute headers.key?("Payment-Receipt")
   end
 
+  def test_normalizes_method_prefixed_sinatra_route_scope
+    handler = mock_handler
+    app = lambda { |env|
+      env["mpp.charge"] = {amount: "1.00"}
+      [200, {}, ["OK"]]
+    }
+    middleware = Mpp::Server::Middleware.new(app, handler: handler)
+
+    status, headers, _body = middleware.call(
+      minimal_env.merge(
+        "PATH_INFO" => "/paid/one",
+        "QUERY_STRING" => "view=full",
+        "sinatra.route" => "GET /paid/:id"
+      )
+    )
+
+    assert_equal 402, status
+    challenge = Mpp::Challenge.from_www_authenticate(headers["WWW-Authenticate"])
+    assert_equal(
+      {"route" => "/paid/:id", "resource" => "/paid/one", "query" => "view=full"},
+      challenge.request["_mppx_scope"]
+    )
+  end
+
   def test_rejects_paid_retry_with_tampered_body_digest
     handler = mock_handler
     app = lambda { |env|

--- a/test/mpp/test_middleware.rb
+++ b/test/mpp/test_middleware.rb
@@ -20,6 +20,18 @@ class TestMiddleware < Minitest::Test
     assert_equal "text/plain", headers["Content-Type"]
   end
 
+  def test_does_not_read_request_body_when_no_charge
+    input = CountingInput.new("x" * 1024)
+    app = ->(_env) { [200, {}, ["OK"]] }
+    middleware = Mpp::Server::Middleware.new(app, handler: mock_handler)
+
+    status, _headers, body = middleware.call(minimal_env.merge("rack.input" => input))
+
+    assert_equal 200, status
+    assert_equal ["OK"], body
+    assert_equal 0, input.reads
+  end
+
   def test_returns_402_when_charge_requested_without_auth
     app = lambda { |env|
       env["mpp.charge"] = {amount: "1.00"}
@@ -257,6 +269,20 @@ class TestMiddleware < Minitest::Test
     end
 
     def read(*args)
+      @input.read(*args)
+    end
+  end
+
+  class CountingInput
+    attr_reader :reads
+
+    def initialize(body)
+      @input = StringIO.new(body)
+      @reads = 0
+    end
+
+    def read(*args)
+      @reads += 1
       @input.read(*args)
     end
   end

--- a/test/mpp/test_middleware.rb
+++ b/test/mpp/test_middleware.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "stringio"
 
 class TestMiddleware < Minitest::Test
   def setup
@@ -63,6 +64,38 @@ class TestMiddleware < Minitest::Test
     assert_equal "no-store", headers["Cache-Control"]
     assert_vary_authorization headers
     assert_equal ["OK"], body
+  end
+
+  def test_rejects_paid_retry_with_tampered_body_digest
+    handler = mock_handler
+    app = lambda { |env|
+      env["mpp.charge"] = {amount: "1.00"}
+      env["rack.input"].read
+      [200, {}, ["OK"]]
+    }
+    middleware = Mpp::Server::Middleware.new(app, handler: handler)
+
+    status, headers, _body = middleware.call(
+      minimal_env.merge("rack.input" => StringIO.new("{\"query\":\"paid\"}"))
+    )
+    assert_equal 402, status
+
+    challenge = Mpp::Challenge.from_www_authenticate(headers["WWW-Authenticate"])
+    assert_equal Mpp::BodyDigest.compute("{\"query\":\"paid\"}"), challenge.digest
+    credential = Mpp::Credential.new(
+      challenge: challenge.to_echo,
+      payload: {"type" => "test", "data" => "ok"}
+    )
+
+    status, headers, _body = middleware.call(
+      minimal_env.merge(
+        "HTTP_AUTHORIZATION" => credential.to_authorization,
+        "rack.input" => StringIO.new("{\"query\":\"tampered\"}")
+      )
+    )
+
+    assert_equal 402, status
+    refute headers.key?("Payment-Receipt")
   end
 
   private

--- a/test/mpp/test_middleware.rb
+++ b/test/mpp/test_middleware.rb
@@ -96,6 +96,8 @@ class TestMiddleware < Minitest::Test
 
     assert_equal 402, status
     refute headers.key?("Payment-Receipt")
+    replacement = Mpp::Challenge.from_www_authenticate(headers["WWW-Authenticate"])
+    assert_equal Mpp::BodyDigest.compute("{\"query\":\"tampered\"}"), replacement.digest
   end
 
   def test_accepts_paid_retry_with_matching_body_digest
@@ -128,6 +130,25 @@ class TestMiddleware < Minitest::Test
     assert_equal 200, status
     assert headers.key?("Payment-Receipt")
     assert_equal [body], response_body
+  end
+
+  def test_preserves_non_rewindable_request_body_for_app
+    handler = mock_handler
+    seen_body = nil
+    app = lambda { |env|
+      env["mpp.charge"] = {amount: "1.00"}
+      seen_body = env["rack.input"].read
+      [200, {}, [env["rack.input"].read]]
+    }
+    middleware = Mpp::Server::Middleware.new(app, handler: handler)
+    body = "{\"query\":\"paid\"}"
+
+    status, _headers, _response_body = middleware.call(
+      minimal_env.merge("rack.input" => NonRewindableInput.new(body))
+    )
+
+    assert_equal 402, status
+    assert_equal body, seen_body
   end
 
   private
@@ -164,5 +185,15 @@ class TestMiddleware < Minitest::Test
       realm: @realm,
       secret_key: @secret_key
     )
+  end
+
+  class NonRewindableInput
+    def initialize(body)
+      @input = StringIO.new(body)
+    end
+
+    def read(*args)
+      @input.read(*args)
+    end
   end
 end

--- a/test/mpp/test_middleware.rb
+++ b/test/mpp/test_middleware.rb
@@ -98,6 +98,38 @@ class TestMiddleware < Minitest::Test
     refute headers.key?("Payment-Receipt")
   end
 
+  def test_accepts_paid_retry_with_matching_body_digest
+    handler = mock_handler
+    app = lambda { |env|
+      env["mpp.charge"] = {amount: "1.00"}
+      [200, {}, [env["rack.input"].read]]
+    }
+    middleware = Mpp::Server::Middleware.new(app, handler: handler)
+
+    body = "{\"query\":\"paid\"}"
+    status, headers, _response_body = middleware.call(
+      minimal_env.merge("rack.input" => StringIO.new(body))
+    )
+    assert_equal 402, status
+
+    challenge = Mpp::Challenge.from_www_authenticate(headers["WWW-Authenticate"])
+    credential = Mpp::Credential.new(
+      challenge: challenge.to_echo,
+      payload: {"type" => "test", "data" => "ok"}
+    )
+
+    status, headers, response_body = middleware.call(
+      minimal_env.merge(
+        "HTTP_AUTHORIZATION" => credential.to_authorization,
+        "rack.input" => StringIO.new(body)
+      )
+    )
+
+    assert_equal 200, status
+    assert headers.key?("Payment-Receipt")
+    assert_equal [body], response_body
+  end
+
   private
 
   def minimal_env

--- a/test/mpp/test_server.rb
+++ b/test/mpp/test_server.rb
@@ -140,6 +140,63 @@ class TestServerVerify < Minitest::Test
     assert_equal [[challenge.id, "success", {name: "tempo", intent: "charge"}]], seen
   end
 
+  def test_successful_verification_with_body_digest
+    request = {"amount" => "1000000"}
+    body = "{\"query\":\"paid\"}"
+    challenge = Mpp::Challenge.create(
+      secret_key: SECRET,
+      realm: REALM,
+      method: "tempo",
+      intent: "charge",
+      request: request,
+      expires: Mpp::Expires.minutes(5),
+      digest: Mpp::BodyDigest.compute(body)
+    )
+    credential = Mpp::Credential.new(
+      challenge: challenge.to_echo,
+      payload: {"type" => "transaction", "signature" => "0xabc"},
+      source: "did:pkh:eip155:4217:0x1234"
+    )
+
+    result = Mpp::Server::Verify.verify_or_challenge(
+      authorization: credential.to_authorization,
+      intent: @intent,
+      request: request,
+      realm: REALM,
+      secret_key: SECRET,
+      body: body
+    )
+
+    assert_instance_of Array, result
+    _credential, receipt = result
+    assert_equal "success", receipt.status
+  end
+
+  def test_rejects_mismatched_body_digest
+    request = {"amount" => "1000000"}
+    challenge = Mpp::Challenge.create(
+      secret_key: SECRET,
+      realm: REALM,
+      method: "tempo",
+      intent: "charge",
+      request: request,
+      expires: Mpp::Expires.minutes(5),
+      digest: Mpp::BodyDigest.compute("{\"query\":\"paid\"}")
+    )
+    credential = Mpp::Credential.new(challenge: challenge.to_echo, payload: {"type" => "hash", "hash" => "0x123"})
+
+    result = Mpp::Server::Verify.verify_or_challenge(
+      authorization: credential.to_authorization,
+      intent: @intent,
+      request: request,
+      realm: REALM,
+      secret_key: SECRET,
+      body: "{\"query\":\"tampered\"}"
+    )
+
+    assert_instance_of Mpp::Challenge, result
+  end
+
   def test_rejects_wrong_secret
     request = {"amount" => "1000000"}
     challenge = Mpp::Challenge.create(

--- a/test/mpp/test_server.rb
+++ b/test/mpp/test_server.rb
@@ -197,6 +197,31 @@ class TestServerVerify < Minitest::Test
     assert_instance_of Mpp::Challenge, result
   end
 
+  def test_rejects_digest_bound_credential_without_body
+    request = {"amount" => "1000000"}
+    challenge = Mpp::Challenge.create(
+      secret_key: SECRET,
+      realm: REALM,
+      method: "tempo",
+      intent: "charge",
+      request: request,
+      expires: Mpp::Expires.minutes(5),
+      digest: Mpp::BodyDigest.compute("{\"query\":\"paid\"}")
+    )
+    credential = Mpp::Credential.new(challenge: challenge.to_echo, payload: {"type" => "hash", "hash" => "0x123"})
+
+    result = Mpp::Server::Verify.verify_or_challenge(
+      authorization: credential.to_authorization,
+      intent: @intent,
+      request: request,
+      realm: REALM,
+      secret_key: SECRET
+    )
+
+    assert_instance_of Mpp::Challenge, result
+    assert_nil result.digest
+  end
+
   def test_rejects_wrong_secret
     request = {"amount" => "1000000"}
     challenge = Mpp::Challenge.create(


### PR DESCRIPTION
## Summary
- add server-side body digest binding so challenges include request body digests and verification rejects mismatched bodies
- bind framework route/resource/query scope into charge requests for route replay protection
- normalize method-prefixed Rack route patterns such as Sinatra's `GET /paid/:id`

Refs OSS-326, OSS-329.

## Test plan
- `ruby -c lib/mpp/server/middleware.rb && ruby -c test/mpp/test_middleware.rb`

Full Ruby test run was blocked locally because Bundler 2.6.9 / bundled gems were unavailable, and mise Ruby 3.3 installation failed compiling psych on this machine.