### PR TITLE
fix: dedup transaction credential broadcasts

### DIFF
--- a/lib/mpp.rb
+++ b/lib/mpp.rb
@@ -58,6 +58,7 @@ module Mpp
   autoload :PaymentActionRequiredError, "mpp/errors"
   autoload :BadRequestError, "mpp/errors"
   autoload :VerificationError, "mpp/errors"
+  autoload :TransactionPendingError, "mpp/errors"
   autoload :ParseError, "mpp/errors"
   autoload :InsufficientBalanceError, "mpp/errors"
   autoload :InvalidSignatureError, "mpp/errors"

--- a/lib/mpp/errors.rb
+++ b/lib/mpp/errors.rb
@@ -10,6 +10,9 @@ module Mpp
   # Base verification error.
   class VerificationError < StandardError; end
 
+  # Retryable verification error for transactions that were accepted but not mined yet.
+  class TransactionPendingError < VerificationError; end
+
   # Base class for all payment-related errors with RFC 9457 support.
   class PaymentError < StandardError
     extend T::Sig

--- a/lib/mpp/methods/tempo/intents.rb
+++ b/lib/mpp/methods/tempo/intents.rb
@@ -186,6 +186,7 @@ module Mpp
           end
 
           if reserved_tx_hash && tx_hash.downcase != reserved_tx_hash.downcase
+            @store.delete(store_key) if @store && store_key
             raise Mpp::VerificationError, "Returned transaction hash does not match submitted transaction"
           end
 

--- a/lib/mpp/methods/tempo/intents.rb
+++ b/lib/mpp/methods/tempo/intents.rb
@@ -14,6 +14,8 @@ module Mpp
       TRANSFER_WITH_MEMO_SELECTOR = "95777d59"
       TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
       TRANSFER_WITH_MEMO_TOPIC = "0x57bc7354aa85aed339e000bccffabbc529466af35f0772c8f8ee1145927de7f0"
+      TRANSACTION_PENDING = "transaction:pending"
+      TRANSACTION_VERIFIED = "transaction:verified"
 
       # Tempo charge intent for server-side verification.
       class ChargeIntent
@@ -153,9 +155,12 @@ module Mpp
           if @store
             reserved_tx_hash = raw_transaction_hash(raw_tx)
             store_key = "mpp:charge:#{reserved_tx_hash.downcase}"
-            unless @store.put_if_absent(store_key, reserved_tx_hash)
+            unless @store.put_if_absent(store_key, TRANSACTION_PENDING)
+              raise Mpp::VerificationError, "Transaction hash already used" unless @store.get(store_key) == TRANSACTION_PENDING
+
               receipt_data = fetch_transaction_receipt(rpc_url, reserved_tx_hash)
               verify_transaction_receipt!(receipt_data, request, credential: credential)
+              @store.put(store_key, TRANSACTION_VERIFIED)
               return Mpp::Receipt.success(reserved_tx_hash)
             end
           end
@@ -164,6 +169,13 @@ module Mpp
           begin
             tx_hash = Rpc.call(rpc_url, "eth_sendRawTransaction", [raw_tx])
           rescue => e
+            if reserved_tx_hash && store_key && transaction_submission_may_have_succeeded?(e)
+              receipt_data = fetch_transaction_receipt(rpc_url, reserved_tx_hash)
+              verify_transaction_receipt!(receipt_data, request, credential: credential)
+              @store&.put(store_key, TRANSACTION_VERIFIED)
+              return Mpp::Receipt.success(reserved_tx_hash)
+            end
+
             @store.delete(store_key) if @store && store_key
             raise Mpp::VerificationError, "Transaction submission failed: #{e.message}"
           end
@@ -180,8 +192,20 @@ module Mpp
           tx_hash = reserved_tx_hash || tx_hash
           receipt_data = fetch_transaction_receipt(rpc_url, tx_hash)
           verify_transaction_receipt!(receipt_data, request, credential: credential)
+          @store.put(store_key, TRANSACTION_VERIFIED) if @store && store_key
 
           Mpp::Receipt.success(tx_hash)
+        end
+
+        def transaction_submission_may_have_succeeded?(error)
+          message = "#{error.class}: #{error.message}".downcase
+
+          message.include?("timeout") ||
+            message.include?("timed out") ||
+            message.include?("already known") ||
+            message.include?("already imported") ||
+            message.include?("known transaction") ||
+            message.include?("transaction already exists")
         end
 
         def fetch_transaction_receipt(rpc_url, tx_hash)
@@ -193,7 +217,10 @@ module Mpp
             sleep(RECEIPT_RETRY_DELAY_SECONDS) if attempt < MAX_RECEIPT_RETRY_ATTEMPTS - 1
           end
 
-          raise Mpp::VerificationError, "Transaction receipt not found after retries" unless receipt_data
+          unless receipt_data
+            raise Mpp::TransactionPendingError,
+              "Transaction receipt pending; retry verification later"
+          end
 
           receipt_data
         end

--- a/lib/mpp/methods/tempo/intents.rb
+++ b/lib/mpp/methods/tempo/intents.rb
@@ -148,9 +148,43 @@ module Mpp
           end
 
           rpc_url = get_rpc_url
-          tx_hash = Rpc.call(rpc_url, "eth_sendRawTransaction", [raw_tx])
-          raise Mpp::VerificationError, "No transaction hash returned" unless tx_hash
+          reserved_tx_hash = T.let(nil, T.nilable(String))
+          store_key = T.let(nil, T.nilable(String))
+          if @store
+            reserved_tx_hash = raw_transaction_hash(raw_tx)
+            store_key = "mpp:charge:#{reserved_tx_hash.downcase}"
+            unless @store.put_if_absent(store_key, reserved_tx_hash)
+              receipt_data = fetch_transaction_receipt(rpc_url, reserved_tx_hash)
+              verify_transaction_receipt!(receipt_data, request, credential: credential)
+              return Mpp::Receipt.success(reserved_tx_hash)
+            end
+          end
 
+          tx_hash = T.let(nil, T.nilable(String))
+          begin
+            tx_hash = Rpc.call(rpc_url, "eth_sendRawTransaction", [raw_tx])
+          rescue => e
+            @store.delete(store_key) if @store && store_key
+            raise Mpp::VerificationError, "Transaction submission failed: #{e.message}"
+          end
+
+          unless tx_hash
+            @store.delete(store_key) if @store && store_key
+            raise Mpp::VerificationError, "No transaction hash returned"
+          end
+
+          if reserved_tx_hash && tx_hash.downcase != reserved_tx_hash.downcase
+            raise Mpp::VerificationError, "Returned transaction hash does not match submitted transaction"
+          end
+
+          tx_hash = reserved_tx_hash || tx_hash
+          receipt_data = fetch_transaction_receipt(rpc_url, tx_hash)
+          verify_transaction_receipt!(receipt_data, request, credential: credential)
+
+          Mpp::Receipt.success(tx_hash)
+        end
+
+        def fetch_transaction_receipt(rpc_url, tx_hash)
           receipt_data = T.let(nil, T.untyped)
           MAX_RECEIPT_RETRY_ATTEMPTS.times do |attempt|
             receipt_data = Rpc.call(rpc_url, "eth_getTransactionReceipt", [tx_hash])
@@ -160,6 +194,11 @@ module Mpp
           end
 
           raise Mpp::VerificationError, "Transaction receipt not found after retries" unless receipt_data
+
+          receipt_data
+        end
+
+        def verify_transaction_receipt!(receipt_data, request, credential:)
           raise Mpp::VerificationError, "Transaction reverted" unless receipt_data["status"] == "0x1"
           matched_logs = match_transfer_logs(receipt_data, request, expected_sender: receipt_data["from"])
           unless matched_logs.any?
@@ -167,8 +206,6 @@ module Mpp
               "Transaction must contain a Transfer log matching request parameters"
           end
           assert_challenge_bound_memo(matched_logs, credential.challenge) unless request.method_details.memo
-
-          Mpp::Receipt.success(tx_hash)
         end
 
         def verify_transfer_logs(receipt, request, expected_sender: nil)
@@ -299,6 +336,20 @@ module Mpp
           end
 
           raise Mpp::VerificationError, "Invalid transaction: no matching payment call found" unless found
+        end
+
+        def raw_transaction_hash(raw_tx)
+          Kernel.require "eth"
+
+          hex = raw_tx.delete_prefix("0x")
+          unless hex.match?(/\A[0-9a-fA-F]+\z/) && hex.length.even?
+            raise Mpp::VerificationError, "Invalid transaction signature"
+          end
+
+          "0x#{Eth::Util.keccak256([hex].pack("H*")).unpack1("H*")}"
+        rescue LoadError
+          raise Mpp::VerificationError,
+            "eth gem is required to compute transaction hash for transaction replay protection"
         end
 
         def match_transfer_calldata(call_data_hex, request)

--- a/test/mpp/methods/tempo/test_charge_intent.rb
+++ b/test/mpp/methods/tempo/test_charge_intent.rb
@@ -244,6 +244,33 @@ class TestTempoChargeIntent < Minitest::Test
     assert_equal 1, methods.count("eth_getTransactionReceipt")
   end
 
+  def test_transaction_credential_releases_reservation_on_returned_hash_mismatch
+    raw_tx = "0xabcdef1234567890"
+    tx_hash = raw_transaction_hash(raw_tx)
+    wrong_tx_hash = "0x#{"12" * 32}"
+    challenge_id = "challenge-123"
+    store = Mpp::MemoryStore.new
+    intent = Mpp::Methods::Tempo::ChargeIntent.new(rpc_url: "https://rpc.example.test", store: store)
+    credential = transaction_credential(raw_tx, challenge_id: challenge_id)
+
+    Mpp::Methods::Tempo::Rpc.stub(:call, ->(_rpc_url, method, params) {
+      case method
+      when "eth_sendRawTransaction"
+        assert_equal [raw_tx], params
+        wrong_tx_hash
+      else
+        raise "unexpected RPC method: #{method}"
+      end
+    }) do
+      error = assert_raises(Mpp::VerificationError) do
+        intent.verify(credential, request_hash)
+      end
+      assert_match(/Returned transaction hash does not match/, error.message)
+    end
+
+    assert_nil store.get("mpp:charge:#{tx_hash.downcase}")
+  end
+
   def test_proof_credential_replay_rejected
     account = Mpp::Methods::Tempo::Account.from_key("0x#{"11" * 32}")
     chain_id = 4217

--- a/test/mpp/methods/tempo/test_charge_intent.rb
+++ b/test/mpp/methods/tempo/test_charge_intent.rb
@@ -74,6 +74,95 @@ class TestTempoChargeIntent < Minitest::Test
     assert_equal HASH, result.reference
   end
 
+  def test_transaction_credential_duplicate_fetches_receipt_without_rebroadcast
+    raw_tx = "0xabcdef1234567890"
+    tx_hash = raw_transaction_hash(raw_tx)
+    challenge_id = "challenge-123"
+    memo = Mpp::Methods::Tempo::Attribution.encode(
+      server_id: REALM,
+      challenge_id: challenge_id
+    )
+    receipt_data = receipt([transfer_log(memo: memo)])
+    store = Mpp::MemoryStore.new
+    intent = Mpp::Methods::Tempo::ChargeIntent.new(rpc_url: "https://rpc.example.test", store: store)
+    credential = transaction_credential(raw_tx, challenge_id: challenge_id)
+    calls = []
+
+    Mpp::Methods::Tempo::Rpc.stub(:call, ->(_rpc_url, method, params) {
+      calls << [method, params]
+
+      case method
+      when "eth_sendRawTransaction"
+        assert_equal [raw_tx], params
+        assert_equal tx_hash, store.get("mpp:charge:#{tx_hash.downcase}")
+        tx_hash
+      when "eth_getTransactionReceipt"
+        assert_equal [tx_hash], params
+        receipt_data
+      else
+        raise "unexpected RPC method: #{method}"
+      end
+    }) do
+      first = intent.verify(credential, request_hash)
+      second = intent.verify(credential, request_hash)
+
+      assert_equal tx_hash, first.reference
+      assert_equal tx_hash, second.reference
+    end
+
+    methods = calls.map(&:first)
+    assert_equal 1, methods.count("eth_sendRawTransaction")
+    assert_equal 2, methods.count("eth_getTransactionReceipt")
+  end
+
+  def test_transaction_credential_releases_reservation_on_broadcast_failure
+    raw_tx = "0xabcdef1234567890"
+    tx_hash = raw_transaction_hash(raw_tx)
+    challenge_id = "challenge-123"
+    memo = Mpp::Methods::Tempo::Attribution.encode(
+      server_id: REALM,
+      challenge_id: challenge_id
+    )
+    receipt_data = receipt([transfer_log(memo: memo)])
+    store = Mpp::MemoryStore.new
+    intent = Mpp::Methods::Tempo::ChargeIntent.new(rpc_url: "https://rpc.example.test", store: store)
+    credential = transaction_credential(raw_tx, challenge_id: challenge_id)
+    fail_broadcast = true
+    calls = []
+
+    Mpp::Methods::Tempo::Rpc.stub(:call, ->(_rpc_url, method, params) {
+      calls << [method, params]
+
+      case method
+      when "eth_sendRawTransaction"
+        assert_equal [raw_tx], params
+        if fail_broadcast
+          fail_broadcast = false
+          raise "network down"
+        end
+        tx_hash
+      when "eth_getTransactionReceipt"
+        assert_equal [tx_hash], params
+        receipt_data
+      else
+        raise "unexpected RPC method: #{method}"
+      end
+    }) do
+      error = assert_raises(Mpp::VerificationError) do
+        intent.verify(credential, request_hash)
+      end
+      assert_match(/Transaction submission failed: network down/, error.message)
+      assert_nil store.get("mpp:charge:#{tx_hash.downcase}")
+
+      receipt = intent.verify(credential, request_hash)
+      assert_equal tx_hash, receipt.reference
+    end
+
+    methods = calls.map(&:first)
+    assert_equal 2, methods.count("eth_sendRawTransaction")
+    assert_equal 1, methods.count("eth_getTransactionReceipt")
+  end
+
   def test_proof_credential_replay_rejected
     account = Mpp::Methods::Tempo::Account.from_key("0x#{"11" * 32}")
     chain_id = 4217
@@ -317,6 +406,25 @@ class TestTempoChargeIntent < Minitest::Test
     Mpp::Methods::Tempo::Rpc.stub(:call, ->(_rpc_url, _method, _params) { receipt }) do
       intent.verify(credential, request_hash)
     end
+  end
+
+  def raw_transaction_hash(raw_tx)
+    require "eth"
+
+    "0x#{Eth::Util.keccak256([raw_tx.delete_prefix("0x")].pack("H*")).unpack1("H*")}"
+  end
+
+  def transaction_credential(raw_tx, challenge_id:)
+    Mpp::Credential.new(
+      challenge: Mpp::ChallengeEcho.new(
+        id: challenge_id,
+        realm: REALM,
+        method: "tempo",
+        intent: "charge",
+        request: ""
+      ),
+      payload: {"type" => "transaction", "signature" => raw_tx}
+    )
   end
 
   def verify_hash(receipt, challenge_id:, memo: nil)

--- a/test/mpp/methods/tempo/test_charge_intent.rb
+++ b/test/mpp/methods/tempo/test_charge_intent.rb
@@ -74,7 +74,7 @@ class TestTempoChargeIntent < Minitest::Test
     assert_equal HASH, result.reference
   end
 
-  def test_transaction_credential_duplicate_fetches_receipt_without_rebroadcast
+  def test_transaction_credential_replay_rejected_after_success
     raw_tx = "0xabcdef1234567890"
     tx_hash = raw_transaction_hash(raw_tx)
     challenge_id = "challenge-123"
@@ -94,7 +94,7 @@ class TestTempoChargeIntent < Minitest::Test
       case method
       when "eth_sendRawTransaction"
         assert_equal [raw_tx], params
-        assert_equal tx_hash, store.get("mpp:charge:#{tx_hash.downcase}")
+        assert_equal Mpp::Methods::Tempo::TRANSACTION_PENDING, store.get("mpp:charge:#{tx_hash.downcase}")
         tx_hash
       when "eth_getTransactionReceipt"
         assert_equal [tx_hash], params
@@ -104,18 +104,99 @@ class TestTempoChargeIntent < Minitest::Test
       end
     }) do
       first = intent.verify(credential, request_hash)
-      second = intent.verify(credential, request_hash)
-
       assert_equal tx_hash, first.reference
-      assert_equal tx_hash, second.reference
+
+      error = assert_raises(Mpp::VerificationError) do
+        intent.verify(credential, request_hash)
+      end
+      assert_match(/Transaction hash already used/, error.message)
     end
 
     methods = calls.map(&:first)
     assert_equal 1, methods.count("eth_sendRawTransaction")
-    assert_equal 2, methods.count("eth_getTransactionReceipt")
+    assert_equal 1, methods.count("eth_getTransactionReceipt")
   end
 
-  def test_transaction_credential_releases_reservation_on_broadcast_failure
+  def test_transaction_credential_duplicate_pending_raises_pending_without_rebroadcast
+    raw_tx = "0xabcdef1234567890"
+    tx_hash = raw_transaction_hash(raw_tx)
+    challenge_id = "challenge-123"
+    store = Mpp::MemoryStore.new
+    store.put("mpp:charge:#{tx_hash.downcase}", Mpp::Methods::Tempo::TRANSACTION_PENDING)
+    intent = Mpp::Methods::Tempo::ChargeIntent.new(rpc_url: "https://rpc.example.test", store: store)
+    credential = transaction_credential(raw_tx, challenge_id: challenge_id)
+    calls = []
+
+    Mpp::Methods::Tempo::Rpc.stub(:call, ->(_rpc_url, method, params) {
+      calls << [method, params]
+
+      case method
+      when "eth_getTransactionReceipt"
+        assert_equal [tx_hash], params
+        nil
+      else
+        raise "unexpected RPC method: #{method}"
+      end
+    }) do
+      intent.stub(:sleep, ->(*_) {}) do
+        error = assert_raises(Mpp::TransactionPendingError) do
+          intent.verify(credential, request_hash)
+        end
+        assert_match(/pending/, error.message)
+      end
+    end
+
+    methods = calls.map(&:first)
+    assert_equal 0, methods.count("eth_sendRawTransaction")
+    assert_equal Mpp::Methods::Tempo::MAX_RECEIPT_RETRY_ATTEMPTS,
+      methods.count("eth_getTransactionReceipt")
+    assert_equal Mpp::Methods::Tempo::TRANSACTION_PENDING, store.get("mpp:charge:#{tx_hash.downcase}")
+  end
+
+  def test_transaction_credential_recovers_receipt_after_ambiguous_broadcast_error
+    raw_tx = "0xabcdef1234567890"
+    tx_hash = raw_transaction_hash(raw_tx)
+    challenge_id = "challenge-123"
+    memo = Mpp::Methods::Tempo::Attribution.encode(
+      server_id: REALM,
+      challenge_id: challenge_id
+    )
+    receipt_data = receipt([transfer_log(memo: memo)])
+    store = Mpp::MemoryStore.new
+    intent = Mpp::Methods::Tempo::ChargeIntent.new(rpc_url: "https://rpc.example.test", store: store)
+    credential = transaction_credential(raw_tx, challenge_id: challenge_id)
+    calls = []
+
+    Mpp::Methods::Tempo::Rpc.stub(:call, ->(_rpc_url, method, params) {
+      calls << [method, params]
+
+      case method
+      when "eth_sendRawTransaction"
+        assert_equal [raw_tx], params
+        raise "already known"
+      when "eth_getTransactionReceipt"
+        assert_equal [tx_hash], params
+        receipt_data
+      else
+        raise "unexpected RPC method: #{method}"
+      end
+    }) do
+      result = intent.verify(credential, request_hash)
+      assert_equal tx_hash, result.reference
+
+      error = assert_raises(Mpp::VerificationError) do
+        intent.verify(credential, request_hash)
+      end
+      assert_match(/Transaction hash already used/, error.message)
+    end
+
+    methods = calls.map(&:first)
+    assert_equal 1, methods.count("eth_sendRawTransaction")
+    assert_equal 1, methods.count("eth_getTransactionReceipt")
+    assert_equal Mpp::Methods::Tempo::TRANSACTION_VERIFIED, store.get("mpp:charge:#{tx_hash.downcase}")
+  end
+
+  def test_transaction_credential_releases_reservation_on_definitive_broadcast_failure
     raw_tx = "0xabcdef1234567890"
     tx_hash = raw_transaction_hash(raw_tx)
     challenge_id = "challenge-123"
@@ -138,7 +219,7 @@ class TestTempoChargeIntent < Minitest::Test
         assert_equal [raw_tx], params
         if fail_broadcast
           fail_broadcast = false
-          raise "network down"
+          raise "insufficient funds"
         end
         tx_hash
       when "eth_getTransactionReceipt"
@@ -151,7 +232,7 @@ class TestTempoChargeIntent < Minitest::Test
       error = assert_raises(Mpp::VerificationError) do
         intent.verify(credential, request_hash)
       end
-      assert_match(/Transaction submission failed: network down/, error.message)
+      assert_match(/Transaction submission failed: insufficient funds/, error.message)
       assert_nil store.get("mpp:charge:#{tx_hash.downcase}")
 
       receipt = intent.verify(credential, request_hash)


### PR DESCRIPTION
## Summary
- compute and reserve transaction credential hashes before broadcast when a store is configured
- make duplicate transaction credential retries fetch and verify the receipt without rebroadcasting
- release the reservation on broadcast failure so transient failures can be retried