### PR TITLE
feat: add client-side Tempo chain pinning

### DIFF
--- a/lib/mpp/methods/tempo/client_method.rb
+++ b/lib/mpp/methods/tempo/client_method.rb
@@ -67,22 +67,20 @@ module Mpp
           memo = method_details["memo"]
           memo ||= Attribution.encode(server_id: challenge.realm, client_id: @client_id, challenge_id: challenge.id)
 
-          # Resolve RPC URL from challenge's chainId
+          # Resolve RPC URL from challenge's chainId. Normalize the configured pin
+          # once (it may be a String from ENV/config) so it compares equal to
+          # integer chain ids everywhere, including the downstream RPC check.
           resolved_rpc_url = @rpc_url
           expected_chain_id = nil
+          configured_chain_id = @chain_id.nil? ? nil : Integer(@chain_id)
           challenge_chain_id = method_details["chainId"]
           if challenge_chain_id
             begin
               parsed_chain_id = Integer(challenge_chain_id)
               # Chain pinning: reject a challenge whose chainId conflicts with the
-              # configured chain, before any RPC call or signing. Normalize the
-              # configured value (which may be a String from ENV/config) so that
-              # e.g. "42431" and 42431 are treated as equal.
-              if @chain_id
-                configured_chain_id = Integer(@chain_id)
-                if parsed_chain_id != configured_chain_id
-                  raise TransactionError, "Chain ID mismatch: expected #{configured_chain_id}, got #{parsed_chain_id}"
-                end
+              # configured chain, before any RPC call or signing.
+              if configured_chain_id && parsed_chain_id != configured_chain_id
+                raise TransactionError, "Chain ID mismatch: expected #{configured_chain_id}, got #{parsed_chain_id}"
               end
               resolved = Defaults::CHAIN_RPC_URLS[parsed_chain_id]
               if resolved
@@ -94,7 +92,7 @@ module Mpp
             end
           end
 
-          expected_chain_id ||= @chain_id
+          expected_chain_id ||= configured_chain_id
 
           # Proof mode: sign EIP-712 typed data (no transaction needed)
           if mode == :proof

--- a/lib/mpp/methods/tempo/client_method.rb
+++ b/lib/mpp/methods/tempo/client_method.rb
@@ -74,6 +74,11 @@ module Mpp
           if challenge_chain_id
             begin
               parsed_chain_id = Integer(challenge_chain_id)
+              # Chain pinning: reject a challenge whose chainId conflicts with the
+              # configured chain, before any RPC call or signing.
+              if @chain_id && parsed_chain_id != @chain_id
+                raise TransactionError, "Chain ID mismatch: expected #{@chain_id}, got #{parsed_chain_id}"
+              end
               resolved = Defaults::CHAIN_RPC_URLS[parsed_chain_id]
               if resolved
                 resolved_rpc_url = resolved

--- a/lib/mpp/methods/tempo/client_method.rb
+++ b/lib/mpp/methods/tempo/client_method.rb
@@ -75,9 +75,14 @@ module Mpp
             begin
               parsed_chain_id = Integer(challenge_chain_id)
               # Chain pinning: reject a challenge whose chainId conflicts with the
-              # configured chain, before any RPC call or signing.
-              if @chain_id && parsed_chain_id != @chain_id
-                raise TransactionError, "Chain ID mismatch: expected #{@chain_id}, got #{parsed_chain_id}"
+              # configured chain, before any RPC call or signing. Normalize the
+              # configured value (which may be a String from ENV/config) so that
+              # e.g. "42431" and 42431 are treated as equal.
+              if @chain_id
+                configured_chain_id = Integer(@chain_id)
+                if parsed_chain_id != configured_chain_id
+                  raise TransactionError, "Chain ID mismatch: expected #{configured_chain_id}, got #{parsed_chain_id}"
+                end
               end
               resolved = Defaults::CHAIN_RPC_URLS[parsed_chain_id]
               if resolved

--- a/test/mpp/methods/tempo/test_client_method.rb
+++ b/test/mpp/methods/tempo/test_client_method.rb
@@ -157,6 +157,19 @@ class TestTempoChainPinning < Minitest::Test
     assert_equal "did:pkh:eip155:42431:#{RECIPIENT}", credential.source
   end
 
+  def test_accepts_matching_string_pinned_chain_id
+    # chain_id may be configured as a String (e.g. from ENV); it should be
+    # normalized before comparison so a matching chain is not rejected.
+    method = make_method(chain_id: "42431")
+    challenge = make_challenge(chain_id: 42_431)
+
+    credential = with_stubbed_transfer(method, source_chain_id: 42_431, expected_chain_id: 42_431) do
+      method.create_credential(challenge)
+    end
+
+    assert_equal "did:pkh:eip155:42431:#{RECIPIENT}", credential.source
+  end
+
   def test_unpinned_accepts_any_chain_id
     method = make_method(chain_id: nil)
     challenge = make_challenge(chain_id: 1)

--- a/test/mpp/methods/tempo/test_client_method.rb
+++ b/test/mpp/methods/tempo/test_client_method.rb
@@ -193,4 +193,17 @@ class TestTempoChainPinning < Minitest::Test
 
     assert_equal "did:pkh:eip155:42431:#{RECIPIENT}", credential.source
   end
+
+  def test_custom_chain_string_pin_normalizes_downstream
+    # Custom chain (not in CHAIN_RPC_URLS) with a String pin: the normalized
+    # integer must reach the downstream check so a matching chain is not rejected.
+    method = make_method(chain_id: "99999")
+    challenge = make_challenge(chain_id: 99_999)
+
+    credential = with_stubbed_transfer(method, source_chain_id: 99_999, expected_chain_id: 99_999) do
+      method.create_credential(challenge)
+    end
+
+    assert_equal "did:pkh:eip155:99999:#{RECIPIENT}", credential.source
+  end
 end

--- a/test/mpp/methods/tempo/test_client_method.rb
+++ b/test/mpp/methods/tempo/test_client_method.rb
@@ -94,3 +94,90 @@ class TestTempoExpectedRecipients < Minitest::Test
     refute_match(/Unexpected recipient/, err.message)
   end
 end
+
+class TestTempoChainPinning < Minitest::Test
+  RECIPIENT = "0x0000000000000000000000000000000000000001"
+  SIGNED_TX = "0xdeadbeef"
+
+  def stub_account
+    Struct.new(:address, :type).new(RECIPIENT, "local")
+  end
+
+  def make_method(chain_id:)
+    Mpp::Methods::Tempo::TempoMethod.new(account: stub_account, chain_id: chain_id)
+  end
+
+  def make_challenge(chain_id: nil)
+    request = {
+      "amount" => "1000000",
+      "currency" => "USD",
+      "recipient" => RECIPIENT
+    }
+    request["methodDetails"] = {"chainId" => chain_id} if chain_id
+
+    Mpp::Challenge.new(
+      id: "test-id",
+      method: "tempo",
+      intent: "charge",
+      request: request,
+      realm: "test.example.com"
+    )
+  end
+
+  # The pin check runs before `build_tempo_transfer`, so stubbing it keeps the
+  # positive cases deterministic and network-free while still exercising the pin.
+  # `source_chain_id` is the chain the transfer reports (used in the DID);
+  # `expected_chain_id` is the resolved pin asserted as passed downstream.
+  def with_stubbed_transfer(method, source_chain_id:, expected_chain_id:)
+    stub = lambda do |*, **kwargs|
+      assert_equal expected_chain_id, kwargs[:expected_chain_id]
+      [SIGNED_TX, source_chain_id]
+    end
+    method.stub(:build_tempo_transfer, stub) { yield }
+  end
+
+  def test_rejects_conflicting_chain_id
+    method = make_method(chain_id: 42_431)
+    challenge = make_challenge(chain_id: 1)
+
+    err = assert_raises(Mpp::Methods::Tempo::TransactionError) do
+      method.create_credential(challenge)
+    end
+    assert_equal "Chain ID mismatch: expected 42431, got 1", err.message
+  end
+
+  def test_accepts_matching_chain_id
+    method = make_method(chain_id: 42_431)
+    challenge = make_challenge(chain_id: 42_431)
+
+    credential = with_stubbed_transfer(method, source_chain_id: 42_431, expected_chain_id: 42_431) do
+      method.create_credential(challenge)
+    end
+
+    assert_equal "did:pkh:eip155:42431:#{RECIPIENT}", credential.source
+  end
+
+  def test_unpinned_accepts_any_chain_id
+    method = make_method(chain_id: nil)
+    challenge = make_challenge(chain_id: 1)
+
+    # chain 1 is unknown to CHAIN_RPC_URLS and no pin is set, so no expected
+    # chain is enforced downstream; the transfer's reported chain drives the DID.
+    credential = with_stubbed_transfer(method, source_chain_id: 1, expected_chain_id: nil) do
+      method.create_credential(challenge)
+    end
+
+    assert_equal "did:pkh:eip155:1:#{RECIPIENT}", credential.source
+  end
+
+  def test_omitted_challenge_chain_id_uses_pin
+    method = make_method(chain_id: 42_431)
+    challenge = make_challenge(chain_id: nil)
+
+    credential = with_stubbed_transfer(method, source_chain_id: 42_431, expected_chain_id: 42_431) do
+      method.create_credential(challenge)
+    end
+
+    assert_equal "did:pkh:eip155:42431:#{RECIPIENT}", credential.source
+  end
+end


### PR DESCRIPTION
Rejects charge challenges whose `methodDetails.chainId` conflicts with the configured `chain_id`, before any RPC call or signing. Reuses the existing `chain_id` config as the pin. Matches the mpp-go conformance ABI. 

Part of OSS-306