### PR TITLE
feat: simulate sponsored txs before broadcast

### DIFF
--- a/lib/mpp/methods/tempo/intents.rb
+++ b/lib/mpp/methods/tempo/intents.rb
@@ -135,9 +135,12 @@ module Mpp
 
           raw_tx = payload.signature
 
+          # Simulation payload for the locally co-signed tx, if we sponsor it.
+          simulate_payload = nil
+
           if request.method_details.fee_payer
             if fee_payer
-              raw_tx = cosign_as_fee_payer(raw_tx, request.currency, request: request)
+              raw_tx, simulate_payload = cosign_as_fee_payer(raw_tx, request.currency, request: request)
             else
               fee_payer_url = request.method_details.fee_payer_url || Defaults::DEFAULT_FEE_PAYER_URL
               result = Rpc.call(fee_payer_url, "eth_signRawTransaction", [raw_tx])
@@ -148,6 +151,11 @@ module Mpp
           end
 
           rpc_url = get_rpc_url
+
+          # We pay the gas, so simulate the co-signed tx first and bail if it
+          # would revert. Fails closed: no simulation, no broadcast.
+          simulate_before_broadcast(simulate_payload, rpc_url) if simulate_payload
+
           tx_hash = Rpc.call(rpc_url, "eth_sendRawTransaction", [raw_tx])
           raise Mpp::VerificationError, "No transaction hash returned" unless tx_hash
 
@@ -459,7 +467,95 @@ module Mpp
           fee_payer_sig = fee_payer.sign_hash(fee_payer_hash)
 
           signed = tx_to_sign.with(fee_payer_signature: fee_payer_sig)
-          "0x#{signed.encoded_2718.unpack1("H*")}"
+          raw_tx = "0x#{signed.encoded_2718.unpack1("H*")}"
+
+          [raw_tx, build_simulate_payload(tx_to_sign, recovered_addr, fee_payer_sig)]
+        end
+
+        # Build a `tempo_simulateV1` payload for the co-signed `0x76` tx.
+        #
+        # Carries the recovered sender as `from` (the node needs it to model the
+        # sender) plus the sponsor fields (`feeToken`, `feePayerSignature`) so the
+        # node simulates the same tx we are about to broadcast.
+        def build_simulate_payload(tx, sender, fee_payer_sig)
+          tx_request = {
+            "from" => sender,
+            "type" => "0x76",
+            "chainId" => to_hex(tx.chain_id),
+            "nonce" => to_hex(tx.nonce),
+            "nonceKey" => to_hex(tx.nonce_key),
+            "gas" => to_hex(tx.gas_limit),
+            "maxFeePerGas" => to_hex(tx.max_fee_per_gas),
+            "maxPriorityFeePerGas" => to_hex(tx.max_priority_fee_per_gas),
+            "feeToken" => tx.fee_token,
+            "feePayerSignature" => signature_object(fee_payer_sig),
+            "calls" => tx.calls.map do |c|
+              {"to" => c.to, "value" => to_hex(c.value), "input" => c.data}
+            end
+          }
+          tx_request["validBefore"] = to_hex(tx.valid_before) if tx.valid_before
+          tx_request["validAfter"] = to_hex(tx.valid_after) if tx.valid_after
+          access_list = encode_access_list(tx.access_list)
+          tx_request["accessList"] = access_list unless access_list.empty?
+
+          {
+            "blockStateCalls" => [{"calls" => [tx_request]}],
+            # We only care about execution outcome, not mempool admission.
+            "validation" => false,
+            "traceTransfers" => false,
+            "returnFullTransactions" => false
+          }
+        end
+
+        # Simulate the co-signed tx and raise if it would revert. Fails closed:
+        # an RPC error is treated as a failed check, not a pass.
+        def simulate_before_broadcast(simulate_payload, rpc_url)
+          response =
+            begin
+              Rpc.call(rpc_url, "tempo_simulateV1", [simulate_payload])
+            rescue => e
+              raise Mpp::VerificationError, "Pre-broadcast simulation failed: #{e.message}"
+            end
+
+          call = response&.dig("blocks", 0, "calls", 0)
+          raise Mpp::VerificationError, "Pre-broadcast simulation returned no call results" unless call
+
+          status = call["status"]
+          succeeded = status == "0x1" || status == 1 || status == true
+          return if succeeded
+
+          detail = call.dig("error", "message") || "no revert reason returned"
+          raise Mpp::VerificationError,
+            "Sponsored transaction would revert in pre-broadcast simulation: #{detail}"
+        end
+
+        # Encode an integer as a 0x-prefixed hex quantity.
+        def to_hex(value)
+          "0x#{Integer(value).to_s(16)}"
+        end
+
+        # Convert the RLP-decoded access list ([addr_bytes, [key_bytes, ...]])
+        # into the JSON shape the node expects.
+        def encode_access_list(access_list)
+          (access_list || []).map do |address, keys|
+            {
+              "address" => "0x#{address.unpack1("H*")}",
+              "storageKeys" => (keys || []).map { |k| "0x#{k.unpack1("H*")}" }
+            }
+          end
+        end
+
+        # Split a 65-byte (r||s||v) signature into the {r, s, yParity} object the
+        # node expects for `feePayerSignature`.
+        def signature_object(sig)
+          bytes = sig.b
+          v = bytes.getbyte(64)
+          parity = (v >= 27) ? v - 27 : v
+          {
+            "r" => "0x#{bytes[0, 32].unpack1("H*")}",
+            "s" => "0x#{bytes[32, 32].unpack1("H*")}",
+            "yParity" => to_hex(parity)
+          }
         end
       end
     end

--- a/lib/mpp/methods/tempo/intents.rb
+++ b/lib/mpp/methods/tempo/intents.rb
@@ -500,11 +500,24 @@ module Mpp
             "maxFeePerGas" => to_hex(tx.max_fee_per_gas),
             "maxPriorityFeePerGas" => to_hex(tx.max_priority_fee_per_gas),
             "feeToken" => tx.fee_token,
-            "feePayerSignature" => signature_object(fee_payer_sig),
-            "calls" => tx.calls.map do |c|
+            "feePayerSignature" => signature_object(fee_payer_sig)
+          }
+
+          # The node forces `to = CREATE` when a request has no top-level `to`,
+          # appending a phantom CREATE call that trips Tempo's batch rules. Carry
+          # the final call via the top-level `to`/`value`/`input` shorthand (the
+          # builder appends it last, preserving order); keep earlier calls in `calls`.
+          raise Mpp::VerificationError, "Cannot simulate transaction with no calls" if tx.calls.empty?
+          *head_calls, last_call = tx.calls
+          unless head_calls.empty?
+            tx_request["calls"] = head_calls.map do |c|
               {"to" => c.to, "value" => to_hex(c.value), "input" => c.data}
             end
-          }
+          end
+          tx_request["to"] = last_call.to
+          tx_request["value"] = to_hex(last_call.value)
+          tx_request["input"] = last_call.data
+
           tx_request["validBefore"] = to_hex(tx.valid_before) if tx.valid_before
           tx_request["validAfter"] = to_hex(tx.valid_after) if tx.valid_after
           access_list = encode_access_list(tx.access_list)

--- a/lib/mpp/methods/tempo/intents.rb
+++ b/lib/mpp/methods/tempo/intents.rb
@@ -394,6 +394,18 @@ module Mpp
             raise Mpp::VerificationError, "Fee payer transaction must not include fee_token (server sets it)"
           end
 
+          # Reject authorizations we can't replay in tempo_simulateV1, which
+          # would let preflight validate a different tx than we broadcast.
+          tempo_authorization_list = decoded[12]
+          if tempo_authorization_list.is_a?(Array) && !tempo_authorization_list.empty?
+            raise Mpp::VerificationError,
+              "Fee payer envelope must not include tempo_authorization_list (cannot be safely pre-simulated)"
+          end
+          unless key_auth.nil?
+            raise Mpp::VerificationError,
+              "Fee payer envelope must not include key_authorization (cannot be safely pre-simulated)"
+          end
+
           nonce_key = int.call(decoded[6])
           unless nonce_key == (1 << 256) - 1
             raise Mpp::VerificationError, "Fee payer envelope must use expiring nonce key (U256::MAX)"

--- a/test/mpp/methods/tempo/test_transaction.rb
+++ b/test/mpp/methods/tempo/test_transaction.rb
@@ -330,8 +330,12 @@ class TestTempoTransaction < Minitest::Test
     assert tx_request["feePayerSignature"].is_a?(Hash), "feePayerSignature must be present"
     assert tx_request["nonceKey"].start_with?("0x"), "nonceKey must be a hex quantity"
     assert tx_request["validBefore"].start_with?("0x"), "validBefore must be present"
-    assert_equal 1, tx_request["calls"].length
-    assert_equal CURRENCY.downcase, tx_request.dig("calls", 0, "to").downcase
+    # Single call is carried via the top-level to/value/input shorthand (not the
+    # `calls` array) to avoid the node injecting a phantom CREATE call after it.
+    assert_nil tx_request["calls"]
+    assert_equal CURRENCY.downcase, tx_request["to"].downcase
+    assert_equal "0x0", tx_request["value"]
+    assert tx_request["input"].start_with?("0xa9059cbb"), "input must be the transfer calldata"
   end
 
   # A reverting simulation must block the broadcast so we never pay gas for a

--- a/test/mpp/methods/tempo/test_transaction.rb
+++ b/test/mpp/methods/tempo/test_transaction.rb
@@ -139,7 +139,7 @@ class TestTempoTransaction < Minitest::Test
     intent = Mpp::Methods::Tempo::ChargeIntent.new
     Mpp::Methods::Tempo.tempo(intents: {"charge" => intent}, fee_payer: fee_payer)
 
-    signed_raw = intent.send(:cosign_as_fee_payer, raw_tx, CURRENCY)
+    signed_raw, = intent.send(:cosign_as_fee_payer, raw_tx, CURRENCY)
     decoded = decode_raw_tx(signed_raw, 0x76)
 
     assert_equal CURRENCY.downcase.delete_prefix("0x"), decoded[10].unpack1("H*")
@@ -176,12 +176,17 @@ class TestTempoTransaction < Minitest::Test
     intent = Mpp::Methods::Tempo::ChargeIntent.new
     Mpp::Methods::Tempo.tempo(intents: {"charge" => intent}, fee_payer: fee_payer)
 
-    signed_raw = intent.send(:cosign_as_fee_payer, raw_tx, CURRENCY)
+    signed_raw, payload = intent.send(:cosign_as_fee_payer, raw_tx, CURRENCY)
     decoded = decode_raw_tx(signed_raw, 0x76)
 
     assert_equal access_list, decoded[5]
     assert_equal 3, decoded[11].length
     assert_equal 65, decoded[13].bytesize
+
+    # The simulated tx must carry the same access list as the broadcast tx.
+    sim_access_list = payload.dig("blockStateCalls", 0, "calls", 0, "accessList")
+    assert_equal CURRENCY.downcase, sim_access_list.dig(0, "address").downcase
+    assert_equal ["0x#{"00" * 32}"], sim_access_list.dig(0, "storageKeys")
   end
 
   def test_charge_intent_rejects_non_allowlisted_fee_token
@@ -240,7 +245,97 @@ class TestTempoTransaction < Minitest::Test
     assert_includes error.message, "not allowed by fee payer policy"
   end
 
+  # The simulate payload must target the co-signed tx: the recovered sender as
+  # `from`, the sponsor fields the node needs (feeToken, feePayerSignature), the
+  # payment calls, the expiring nonceKey, the validity window, and validation off.
+  def test_cosign_returns_simulate_payload_with_sponsor_abi
+    skip "eth/rlp gems not available" unless eth_and_rlp_available?
+
+    _intent, payload, payer = cosign_fixture
+    tx_request = payload.dig("blockStateCalls", 0, "calls", 0)
+
+    assert_equal false, payload["validation"]
+    assert_equal "0x76", tx_request["type"]
+    # `from` must be the sender recovered from the co-signed tx.
+    assert_equal payer.address.downcase, tx_request["from"].downcase
+    assert_equal CURRENCY.downcase, tx_request["feeToken"].downcase
+    assert tx_request["feePayerSignature"].is_a?(Hash), "feePayerSignature must be present"
+    assert tx_request["nonceKey"].start_with?("0x"), "nonceKey must be a hex quantity"
+    assert tx_request["validBefore"].start_with?("0x"), "validBefore must be present"
+    assert_equal 1, tx_request["calls"].length
+    assert_equal CURRENCY.downcase, tx_request.dig("calls", 0, "to").downcase
+  end
+
+  # A reverting simulation must block the broadcast so we never pay gas for a
+  # failing transaction.
+  def test_simulate_before_broadcast_rejects_revert
+    skip "eth/rlp gems not available" unless eth_and_rlp_available?
+
+    intent, payload = cosign_fixture
+    revert = {"blocks" => [{"calls" => [{"status" => "0x0", "error" => {"message" => "execution reverted"}}]}]}
+
+    error = Mpp::Methods::Tempo::Rpc.stub(:call, ->(_url, method, _params) {
+      assert_equal "tempo_simulateV1", method
+      revert
+    }) do
+      assert_raises(Mpp::VerificationError) do
+        intent.send(:simulate_before_broadcast, payload, "https://rpc.example.test")
+      end
+    end
+    assert_includes error.message, "would revert"
+    assert_includes error.message, "execution reverted"
+  end
+
+  # A successful simulation must let the broadcast proceed.
+  def test_simulate_before_broadcast_accepts_success
+    skip "eth/rlp gems not available" unless eth_and_rlp_available?
+
+    intent, payload = cosign_fixture
+    success = {"blocks" => [{"calls" => [{"status" => "0x1"}]}]}
+
+    Mpp::Methods::Tempo::Rpc.stub(:call, ->(_url, _method, _params) { success }) do
+      assert_nil intent.send(:simulate_before_broadcast, payload, "https://rpc.example.test")
+    end
+  end
+
+  # If the simulation RPC itself errors, fail closed.
+  def test_simulate_before_broadcast_fails_closed_on_rpc_error
+    skip "eth/rlp gems not available" unless eth_and_rlp_available?
+
+    intent, payload = cosign_fixture
+
+    error = Mpp::Methods::Tempo::Rpc.stub(:call, ->(_url, _method, _params) { raise "node unavailable" }) do
+      assert_raises(Mpp::VerificationError) do
+        intent.send(:simulate_before_broadcast, payload, "https://rpc.example.test")
+      end
+    end
+    assert_includes error.message, "Pre-broadcast simulation failed"
+  end
+
   private
+
+  # Co-sign an awaiting-fee-payer envelope; returns [intent, simulate_payload, payer].
+  def cosign_fixture
+    payer = Mpp::Methods::Tempo::Account.from_key("0x#{"11" * 32}")
+    fee_payer = Mpp::Methods::Tempo::Account.from_key("0x#{"22" * 32}")
+    raw_tx, = Mpp::Methods::Tempo::Transaction.build_signed_transfer(
+      account: payer,
+      chain_id: 42_431,
+      gas_limit: 1_000_000,
+      gas_price: 1,
+      nonce: 0,
+      nonce_key: (1 << 256) - 1,
+      currency: CURRENCY,
+      transfer_data: transfer_data,
+      valid_before: Time.now.to_i + 60,
+      awaiting_fee_payer: true
+    )
+    intent = Mpp::Methods::Tempo::ChargeIntent.new(rpc_url: "https://rpc.example.test")
+    Mpp::Methods::Tempo.tempo(intents: {"charge" => intent}, fee_payer: fee_payer)
+
+    _signed_raw, payload = intent.send(:cosign_as_fee_payer, raw_tx, CURRENCY)
+    [intent, payload, payer]
+  end
 
   def transfer_data
     to_padded = RECIPIENT.delete_prefix("0x").downcase.rjust(64, "0")

--- a/test/mpp/methods/tempo/test_transaction.rb
+++ b/test/mpp/methods/tempo/test_transaction.rb
@@ -189,6 +189,74 @@ class TestTempoTransaction < Minitest::Test
     assert_equal ["0x#{"00" * 32}"], sim_access_list.dig(0, "storageKeys")
   end
 
+  def test_charge_intent_rejects_tempo_authorization_list
+    skip "eth/rlp gems not available" unless eth_and_rlp_available?
+
+    payer = Mpp::Methods::Tempo::Account.from_key("0x#{"11" * 32}")
+    fee_payer = Mpp::Methods::Tempo::Account.from_key("0x#{"22" * 32}")
+    tx = Mpp::Methods::Tempo::Transaction::SignedTransaction.new(
+      chain_id: 42_431,
+      max_priority_fee_per_gas: 1,
+      max_fee_per_gas: 1,
+      gas_limit: 1_000_000,
+      calls: [Mpp::Methods::Tempo::Transaction::Call.new(to: CURRENCY, value: 0, data: transfer_data)],
+      access_list: [],
+      nonce_key: (1 << 256) - 1,
+      nonce: 0,
+      valid_before: Time.now.to_i + 60,
+      valid_after: nil,
+      fee_token: nil,
+      sender_signature: nil,
+      fee_payer_signature: Mpp::Methods::Tempo::Transaction::EMPTY_SIGNATURE,
+      sender_address: payer.address,
+      tempo_authorization_list: [[pack_hex(CURRENCY)]],
+      key_authorization: nil
+    )
+    sender_signature = payer.sign_hash(tx.signature_hash)
+    raw_tx = "0x#{Mpp::Methods::Tempo::FeePayer.encode(tx.with(sender_signature: sender_signature)).unpack1("H*")}"
+    intent = Mpp::Methods::Tempo::ChargeIntent.new
+    Mpp::Methods::Tempo.tempo(intents: {"charge" => intent}, fee_payer: fee_payer)
+
+    error = assert_raises(Mpp::VerificationError) do
+      intent.send(:cosign_as_fee_payer, raw_tx, CURRENCY)
+    end
+    assert_includes error.message, "tempo_authorization_list"
+  end
+
+  def test_charge_intent_rejects_key_authorization
+    skip "eth/rlp gems not available" unless eth_and_rlp_available?
+
+    payer = Mpp::Methods::Tempo::Account.from_key("0x#{"11" * 32}")
+    fee_payer = Mpp::Methods::Tempo::Account.from_key("0x#{"22" * 32}")
+    tx = Mpp::Methods::Tempo::Transaction::SignedTransaction.new(
+      chain_id: 42_431,
+      max_priority_fee_per_gas: 1,
+      max_fee_per_gas: 1,
+      gas_limit: 1_000_000,
+      calls: [Mpp::Methods::Tempo::Transaction::Call.new(to: CURRENCY, value: 0, data: transfer_data)],
+      access_list: [],
+      nonce_key: (1 << 256) - 1,
+      nonce: 0,
+      valid_before: Time.now.to_i + 60,
+      valid_after: nil,
+      fee_token: nil,
+      sender_signature: nil,
+      fee_payer_signature: Mpp::Methods::Tempo::Transaction::EMPTY_SIGNATURE,
+      sender_address: payer.address,
+      tempo_authorization_list: [],
+      key_authorization: RLP.encode([pack_hex(CURRENCY)])
+    )
+    sender_signature = payer.sign_hash(tx.signature_hash)
+    raw_tx = "0x#{Mpp::Methods::Tempo::FeePayer.encode(tx.with(sender_signature: sender_signature)).unpack1("H*")}"
+    intent = Mpp::Methods::Tempo::ChargeIntent.new
+    Mpp::Methods::Tempo.tempo(intents: {"charge" => intent}, fee_payer: fee_payer)
+
+    error = assert_raises(Mpp::VerificationError) do
+      intent.send(:cosign_as_fee_payer, raw_tx, CURRENCY)
+    end
+    assert_includes error.message, "key_authorization"
+  end
+
   def test_charge_intent_rejects_non_allowlisted_fee_token
     skip "eth/rlp gems not available" unless eth_and_rlp_available?
 


### PR DESCRIPTION
Adds pre-broadcast simulation for locally co-signed sponsored Tempo transactions. Before broadcasting, the server simulates the co-signed tx via `tempo_simulateV1` and refuses to broadcast (fail-closed, including on RPC error) if it would revert, so the sponsor never pays gas for a failing transaction.