### PR TITLE
Bind Stripe externalId to request

### DIFF
--- a/lib/mpp/methods/stripe/charge_intent.rb
+++ b/lib/mpp/methods/stripe/charge_intent.rb
@@ -11,10 +11,11 @@ module Mpp
       class ChargeIntent
         attr_reader :name
 
-        def initialize(secret_key:, api_base: Defaults::STRIPE_API_BASE)
+        def initialize(secret_key:, api_base: Defaults::STRIPE_API_BASE, client: nil)
           @name = "charge"
           @secret_key = secret_key
           @api_base = api_base
+          @client = client
         end
 
         def verify(credential, request)
@@ -31,7 +32,14 @@ module Mpp
           end
 
           spt = payload_data["spt"]
-          external_id = payload_data["externalId"]
+          credential_external_id = payload_data["externalId"]
+          request_external_id = request["externalId"]
+          if !request_external_id.nil? && credential_external_id != request_external_id
+            raise Mpp::InvalidChallengeError.new(
+              challenge_id: credential.challenge.id,
+              reason: "credential externalId does not match request externalId"
+            )
+          end
 
           method_details = request["methodDetails"]
           method_details = {} unless method_details.is_a?(Hash)
@@ -58,15 +66,16 @@ module Mpp
             params[:metadata] = method_details["metadata"].transform_values(&:to_s)
           end
 
-          # Create PaymentIntent via Stripe SDK
-          begin
-            Kernel.require "stripe"
-          rescue LoadError
-            raise "stripe gem is required for Stripe charge verification. Install with: gem install stripe"
+          unless @client
+            begin
+              Kernel.require "stripe"
+            rescue LoadError
+              raise "stripe gem is required for Stripe charge verification. Install with: gem install stripe"
+            end
           end
 
           begin
-            client = ::Stripe::StripeClient.new(@secret_key)
+            client = @client || ::Stripe::StripeClient.new(@secret_key)
             result = client.v1.payment_intents.create(
               params,
               {idempotency_key: stripe_idempotency_key(credential)}
@@ -92,7 +101,7 @@ module Mpp
             raise Mpp::VerificationError, "PaymentIntent #{pi_id} has status: #{status}"
           end
 
-          Mpp::Receipt.success(pi_id, method: "stripe", external_id: external_id)
+          Mpp::Receipt.success(pi_id, method: "stripe", external_id: request_external_id)
         end
 
         private

--- a/lib/mpp/methods/stripe/client_method.rb
+++ b/lib/mpp/methods/stripe/client_method.rb
@@ -29,7 +29,9 @@ module Mpp
           )
 
           payload = {"spt" => spt_id}
-          payload["externalId"] = @external_id if @external_id
+          request_external_id = request["externalId"]
+          payload["externalId"] = request_external_id if request_external_id.is_a?(String)
+          payload["externalId"] = @external_id if !payload.key?("externalId") && @external_id
 
           Mpp::Credential.new(
             challenge: challenge.to_echo,

--- a/lib/mpp/methods/stripe/client_method.rb
+++ b/lib/mpp/methods/stripe/client_method.rb
@@ -31,7 +31,9 @@ module Mpp
           payload = {"spt" => spt_id}
           request_external_id = request["externalId"]
           payload["externalId"] = request_external_id if request_external_id.is_a?(String)
-          payload["externalId"] = @external_id if !payload.key?("externalId") && @external_id
+          if @external_id && !payload.key?("externalId")
+            raise ArgumentError, "external_id must be bound by the challenge request"
+          end
 
           Mpp::Credential.new(
             challenge: challenge.to_echo,

--- a/lib/mpp/methods/stripe/stripe_method.rb
+++ b/lib/mpp/methods/stripe/stripe_method.rb
@@ -14,7 +14,7 @@ module Mpp
 
         def initialize(secret_key:, network_id:, payment_methods: nil,
           metadata: nil, currency: Defaults::DEFAULT_CURRENCY,
-          decimals: Defaults::DEFAULT_DECIMALS)
+          decimals: Defaults::DEFAULT_DECIMALS, external_id: nil)
           unless payment_methods.is_a?(Array) &&
               payment_methods.any? &&
               payment_methods.all? { |type| type.is_a?(String) && !type.strip.empty? }
@@ -26,6 +26,7 @@ module Mpp
           @network_id = network_id
           @payment_methods = payment_methods
           @metadata = metadata
+          @external_id = external_id
           @currency = currency
           @recipient = network_id
           @decimals = decimals
@@ -41,7 +42,9 @@ module Mpp
           method_details["paymentMethodTypes"] = @payment_methods
           method_details["metadata"] = @metadata if @metadata
 
-          request.merge("methodDetails" => method_details)
+          transformed = request.merge("methodDetails" => method_details)
+          transformed["externalId"] = @external_id if !@external_id.nil? && !transformed.key?("externalId")
+          transformed
         end
       end
 
@@ -49,6 +52,7 @@ module Mpp
       def self.stripe(secret_key:, network_id:, payment_methods: nil,
         metadata: nil, currency: Defaults::DEFAULT_CURRENCY,
         decimals: Defaults::DEFAULT_DECIMALS,
+        external_id: nil,
         api_base: Defaults::STRIPE_API_BASE)
         charge_intent = ChargeIntent.new(secret_key: secret_key, api_base: api_base)
 
@@ -58,7 +62,8 @@ module Mpp
           payment_methods: payment_methods,
           metadata: metadata,
           currency: currency,
-          decimals: decimals
+          decimals: decimals,
+          external_id: external_id
         )
 
         method.intents = {"charge" => charge_intent}

--- a/lib/mpp/server/mpp_handler.rb
+++ b/lib/mpp/server/mpp_handler.rb
@@ -63,9 +63,9 @@ module Mpp
       end
 
       # Handle a charge intent.
-      sig { params(authorization: T.nilable(String), amount: String, currency: T.nilable(String), recipient: T.nilable(String), expires: T.nilable(String), description: T.nilable(String), memo: T.nilable(String), fee_payer: T::Boolean, chain_id: T.nilable(Integer), extra: T.nilable(T::Hash[String, String])).returns(T.untyped) }
+      sig { params(authorization: T.nilable(String), amount: String, currency: T.nilable(String), recipient: T.nilable(String), expires: T.nilable(String), description: T.nilable(String), external_id: T.nilable(String), memo: T.nilable(String), fee_payer: T::Boolean, chain_id: T.nilable(Integer), extra: T.nilable(T::Hash[String, String])).returns(T.untyped) }
       def charge(authorization, amount, currency: nil, recipient: nil, expires: nil,
-        description: nil, memo: nil, fee_payer: false, chain_id: nil, extra: nil)
+        description: nil, external_id: nil, memo: nil, fee_payer: false, chain_id: nil, extra: nil)
         intent = @method.intents["charge"]
         raise ArgumentError, "Method #{@method.name} does not support charge intent" unless intent
 
@@ -82,6 +82,7 @@ module Mpp
           "currency" => resolved_currency,
           "recipient" => resolved_recipient
         }
+        request["externalId"] = external_id unless external_id.nil?
 
         if extra
           extra.each do |k, v|

--- a/test/mpp/methods/stripe/test_charge_intent.rb
+++ b/test/mpp/methods/stripe/test_charge_intent.rb
@@ -3,6 +3,7 @@
 
 require "test_helper"
 require "json"
+require "tmpdir"
 
 class TestStripeChargeIntent < Minitest::Test
   FakePaymentIntents = Struct.new(:result, :error, :assertion, :calls, keyword_init: true) do
@@ -29,6 +30,42 @@ class TestStripeChargeIntent < Minitest::Test
   def intent_with_payment_intents(payment_intents)
     client = Struct.new(:v1).new(Struct.new(:payment_intents).new(payment_intents))
     Mpp::Methods::Stripe::ChargeIntent.new(secret_key: "sk_test_fake", client: client)
+  end
+
+  def with_fake_stripe_client(payment_intents)
+    created_secret_keys = []
+    previous_stripe = nil
+    previous_stripe = Object.const_get(:Stripe) if Object.const_defined?(:Stripe, false)
+    Object.send(:remove_const, :Stripe) if Object.const_defined?(:Stripe, false)
+
+    fake_client = Class.new do
+      define_method(:initialize) do |secret_key|
+        created_secret_keys << secret_key
+      end
+
+      define_method(:v1) do
+        Struct.new(:payment_intents).new(payment_intents)
+      end
+    end
+
+    fake_stripe = Module.new
+    fake_stripe.const_set(:StripeClient, fake_client)
+    Object.const_set(:Stripe, fake_stripe)
+
+    Dir.mktmpdir do |dir|
+      fake_stripe_path = File.join(dir, "stripe.rb")
+      File.write(fake_stripe_path, "# fake stripe for tests\n")
+      $LOAD_PATH.unshift(dir)
+      begin
+        yield created_secret_keys
+      ensure
+        $LOAD_PATH.delete(dir)
+        $LOADED_FEATURES.delete(fake_stripe_path)
+      end
+    end
+  ensure
+    Object.send(:remove_const, :Stripe) if Object.const_defined?(:Stripe, false)
+    Object.const_set(:Stripe, previous_stripe) if previous_stripe
   end
 
   def make_credential(payload:, expires: nil)
@@ -109,6 +146,26 @@ class TestStripeChargeIntent < Minitest::Test
     assert_equal "stripe", receipt.method
     assert_equal "ext_1", receipt.external_id
     assert_equal 1, payment_intents.calls.length
+  end
+
+  def test_verify_constructs_stripe_client_when_not_injected
+    credential = make_credential(payload: {"spt" => "spt_test123", "externalId" => "ext_1"})
+    request = make_request(
+      payment_method_types: ["card"],
+      external_id: "ext_1"
+    )
+
+    mock_result = Struct.new(:id, :status).new("pi_abc123", "succeeded")
+    payment_intents = FakePaymentIntents.new(result: mock_result)
+
+    with_fake_stripe_client(payment_intents) do |created_secret_keys|
+      receipt = @intent.verify(credential, request)
+
+      assert_equal ["sk_test_fake"], created_secret_keys
+      assert_equal "pi_abc123", receipt.reference
+      assert_equal "ext_1", receipt.external_id
+      assert_equal 1, payment_intents.calls.length
+    end
   end
 
   def test_verify_rejects_forged_external_id

--- a/test/mpp/methods/stripe/test_charge_intent.rb
+++ b/test/mpp/methods/stripe/test_charge_intent.rb
@@ -5,18 +5,30 @@ require "test_helper"
 require "json"
 
 class TestStripeChargeIntent < Minitest::Test
+  FakePaymentIntents = Struct.new(:result, :error, :assertion, :calls, keyword_init: true) do
+    def initialize(result: nil, error: nil, assertion: nil)
+      super(result: result, error: error, assertion: assertion, calls: [])
+    end
+
+    def create(params, opts)
+      calls << [params, opts]
+      assertion&.call(params, opts)
+      raise error if error
+
+      result
+    end
+  end
+
   def setup
     @intent = Mpp::Methods::Stripe::ChargeIntent.new(
       secret_key: "sk_test_fake",
       api_base: "https://api.stripe.com"
     )
+  end
 
-    @stripe_available = begin
-      require "stripe"
-      true
-    rescue LoadError
-      false
-    end
+  def intent_with_payment_intents(payment_intents)
+    client = Struct.new(:v1).new(Struct.new(:payment_intents).new(payment_intents))
+    Mpp::Methods::Stripe::ChargeIntent.new(secret_key: "sk_test_fake", client: client)
   end
 
   def make_credential(payload:, expires: nil)
@@ -34,12 +46,13 @@ class TestStripeChargeIntent < Minitest::Test
     Mpp::Credential.new(challenge: echo, payload: payload)
   end
 
-  def make_request(amount: "100", currency: "usd", payment_method_types: ["card"], method_details: nil)
+  def make_request(amount: "100", currency: "usd", payment_method_types: ["card"], method_details: nil, external_id: nil)
     req = {
       "amount" => amount,
       "currency" => currency,
       "recipient" => "acct_test123"
     }
+    req["externalId"] = external_id if external_id
     details = {}
     details["paymentMethodTypes"] = payment_method_types unless payment_method_types.nil?
     details.merge!(method_details) if method_details
@@ -71,14 +84,15 @@ class TestStripeChargeIntent < Minitest::Test
   end
 
   def test_verify_calls_stripe_sdk
-    skip "stripe gem not available" unless @stripe_available
-
     credential = make_credential(payload: {"spt" => "spt_test123", "externalId" => "ext_1"})
-    request = make_request(payment_method_types: ["card", "link"], method_details: {"metadata" => {"order" => "123"}})
+    request = make_request(
+      payment_method_types: ["card", "link"],
+      method_details: {"metadata" => {"order" => "123"}},
+      external_id: "ext_1"
+    )
 
     mock_result = Struct.new(:id, :status).new("pi_abc123", "succeeded")
-    mock_pi = Minitest::Mock.new
-    mock_pi.expect(:create, mock_result) do |params, opts|
+    payment_intents = FakePaymentIntents.new(result: mock_result, assertion: ->(params, opts) do
       assert_equal 100, params[:amount]
       assert_equal "usd", params[:currency]
       assert_equal "spt_test123", params[:shared_payment_granted_token]
@@ -87,21 +101,36 @@ class TestStripeChargeIntent < Minitest::Test
       refute params.key?(:automatic_payment_methods)
       assert_equal({"order" => "123"}, params[:metadata])
       assert_equal "mpp-stripe-charge-test-id", opts[:idempotency_key]
-      true
+    end)
+
+    receipt = intent_with_payment_intents(payment_intents).verify(credential, request)
+    assert_equal "success", receipt.status
+    assert_equal "pi_abc123", receipt.reference
+    assert_equal "stripe", receipt.method
+    assert_equal "ext_1", receipt.external_id
+    assert_equal 1, payment_intents.calls.length
+  end
+
+  def test_verify_rejects_forged_external_id
+    credential = make_credential(payload: {"spt" => "spt_test123", "externalId" => "attacker-order-999"})
+    request = make_request(external_id: "server-order-123")
+
+    err = assert_raises(Mpp::InvalidChallengeError) do
+      @intent.verify(credential, request)
     end
+    assert_match(/externalId/, err.message)
+  end
 
-    mock_v1 = Struct.new(:payment_intents).new(mock_pi)
-    mock_client = Struct.new(:v1).new(mock_v1)
+  def test_verify_ignores_payload_only_external_id
+    credential = make_credential(payload: {"spt" => "spt_test123", "externalId" => "attacker-order-999"})
+    request = make_request
 
-    ::Stripe::StripeClient.stub(:new, mock_client) do
-      receipt = @intent.verify(credential, request)
-      assert_equal "success", receipt.status
-      assert_equal "pi_abc123", receipt.reference
-      assert_equal "stripe", receipt.method
-      assert_equal "ext_1", receipt.external_id
-    end
+    mock_result = Struct.new(:id, :status).new("pi_abc123", "succeeded")
+    payment_intents = FakePaymentIntents.new(result: mock_result)
 
-    mock_pi.verify
+    receipt = intent_with_payment_intents(payment_intents).verify(credential, request)
+    assert_nil receipt.external_id
+    assert_equal 1, payment_intents.calls.length
   end
 
   def test_verify_rejects_missing_payment_method_types
@@ -125,67 +154,42 @@ class TestStripeChargeIntent < Minitest::Test
   end
 
   def test_verify_rejects_failed_payment
-    skip "stripe gem not available" unless @stripe_available
-
     credential = make_credential(payload: {"spt" => "spt_test123"})
     request = make_request
 
-    error = ::Stripe::StripeError.new("Card declined")
+    error = StandardError.new("Card declined")
+    payment_intents = FakePaymentIntents.new(error: error)
 
-    mock_pi = Minitest::Mock.new
-    mock_pi.expect(:create, nil) { raise error }
-
-    mock_v1 = Struct.new(:payment_intents).new(mock_pi)
-    mock_client = Struct.new(:v1).new(mock_v1)
-
-    ::Stripe::StripeClient.stub(:new, mock_client) do
-      err = assert_raises(Mpp::VerificationError) do
-        @intent.verify(credential, request)
-      end
-      assert_match(/Card declined/, err.message)
+    err = assert_raises(Mpp::VerificationError) do
+      intent_with_payment_intents(payment_intents).verify(credential, request)
     end
+    assert_match(/Card declined/, err.message)
   end
 
   def test_verify_rejects_replayed_payment
-    skip "stripe gem not available" unless @stripe_available
-
     credential = make_credential(payload: {"spt" => "spt_test123"})
     request = make_request
 
     mock_headers = {"idempotent-replayed" => "true"}
     mock_last_response = Struct.new(:headers).new(mock_headers)
     mock_result = Struct.new(:id, :status, :last_response).new("pi_abc123", "succeeded", mock_last_response)
-    mock_pi = Minitest::Mock.new
-    mock_pi.expect(:create, mock_result, [Hash, {idempotency_key: "mpp-stripe-charge-test-id"}])
+    payment_intents = FakePaymentIntents.new(result: mock_result)
 
-    mock_v1 = Struct.new(:payment_intents).new(mock_pi)
-    mock_client = Struct.new(:v1).new(mock_v1)
-
-    ::Stripe::StripeClient.stub(:new, mock_client) do
-      err = assert_raises(Mpp::VerificationError) do
-        @intent.verify(credential, request)
-      end
-      assert_equal "Payment has already been processed.", err.message
+    err = assert_raises(Mpp::VerificationError) do
+      intent_with_payment_intents(payment_intents).verify(credential, request)
     end
+    assert_equal "Payment has already been processed.", err.message
   end
 
   def test_verify_rejects_requires_action
-    skip "stripe gem not available" unless @stripe_available
-
     credential = make_credential(payload: {"spt" => "spt_test123"})
     request = make_request
 
     mock_result = Struct.new(:id, :status).new("pi_needs3ds", "requires_action")
-    mock_pi = Minitest::Mock.new
-    mock_pi.expect(:create, mock_result, [Hash, {idempotency_key: "mpp-stripe-charge-test-id"}])
+    payment_intents = FakePaymentIntents.new(result: mock_result)
 
-    mock_v1 = Struct.new(:payment_intents).new(mock_pi)
-    mock_client = Struct.new(:v1).new(mock_v1)
-
-    ::Stripe::StripeClient.stub(:new, mock_client) do
-      assert_raises(Mpp::PaymentActionRequiredError) do
-        @intent.verify(credential, request)
-      end
+    assert_raises(Mpp::PaymentActionRequiredError) do
+      intent_with_payment_intents(payment_intents).verify(credential, request)
     end
   end
 end

--- a/test/mpp/methods/stripe/test_stripe_method.rb
+++ b/test/mpp/methods/stripe/test_stripe_method.rb
@@ -170,6 +170,30 @@ class TestStripeMethod < Minitest::Test
     assert_equal "server-order-123", credential.payload["externalId"]
   end
 
+  def test_client_method_rejects_local_external_id_without_request_binding
+    method = Mpp::Methods::Stripe::ClientMethod.new(
+      create_spt: ->(**_params) { "spt_test123" },
+      external_id: "client-order-999",
+      payment_method: "pm_card_visa"
+    )
+    challenge = Mpp::Challenge.create(
+      secret_key: "test-secret",
+      realm: "test-realm",
+      method: "stripe",
+      intent: "charge",
+      request: {
+        "amount" => "100",
+        "currency" => "usd",
+        "methodDetails" => {"networkId" => "acct_test123", "paymentMethodTypes" => ["card"]}
+      }
+    )
+
+    err = assert_raises(ArgumentError) do
+      method.create_credential(challenge)
+    end
+    assert_match(/external_id must be bound/, err.message)
+  end
+
   def test_integration_challenge_round_trip
     method = Mpp::Methods::Stripe.stripe(
       secret_key: "sk_test_fake",

--- a/test/mpp/methods/stripe/test_stripe_method.rb
+++ b/test/mpp/methods/stripe/test_stripe_method.rb
@@ -83,6 +83,30 @@ class TestStripeMethod < Minitest::Test
     refute result["methodDetails"].key?("metadata")
   end
 
+  def test_transform_request_binds_configured_external_id
+    method = Mpp::Methods::Stripe::StripeMethod.new(
+      secret_key: "sk_test_fake",
+      network_id: "acct_test123",
+      payment_methods: ["card"],
+      external_id: "order-123"
+    )
+    result = method.transform_request({"amount" => "100"}, nil)
+
+    assert_equal "order-123", result["externalId"]
+  end
+
+  def test_transform_request_preserves_route_external_id
+    method = Mpp::Methods::Stripe::StripeMethod.new(
+      secret_key: "sk_test_fake",
+      network_id: "acct_test123",
+      payment_methods: ["card"],
+      external_id: "configured-order"
+    )
+    result = method.transform_request({"amount" => "100", "externalId" => "route-order"}, nil)
+
+    assert_equal "route-order", result["externalId"]
+  end
+
   def test_factory_creates_method_with_charge_intent
     method = Mpp::Methods::Stripe.stripe(
       secret_key: "sk_test_fake",
@@ -96,6 +120,54 @@ class TestStripeMethod < Minitest::Test
     assert_equal 2, method.decimals
     assert method.intents.key?("charge")
     assert_instance_of Mpp::Methods::Stripe::ChargeIntent, method.intents["charge"]
+  end
+
+  def test_client_method_echoes_request_bound_external_id
+    method = Mpp::Methods::Stripe::ClientMethod.new(
+      create_spt: ->(**_params) { "spt_test123" },
+      payment_method: "pm_card_visa"
+    )
+    challenge = Mpp::Challenge.create(
+      secret_key: "test-secret",
+      realm: "test-realm",
+      method: "stripe",
+      intent: "charge",
+      request: {
+        "amount" => "100",
+        "currency" => "usd",
+        "externalId" => "server-order-123",
+        "methodDetails" => {"networkId" => "acct_test123", "paymentMethodTypes" => ["card"]}
+      }
+    )
+
+    credential = method.create_credential(challenge)
+
+    assert_equal "spt_test123", credential.payload["spt"]
+    assert_equal "server-order-123", credential.payload["externalId"]
+  end
+
+  def test_client_method_request_external_id_overrides_local_external_id
+    method = Mpp::Methods::Stripe::ClientMethod.new(
+      create_spt: ->(**_params) { "spt_test123" },
+      external_id: "client-order-999",
+      payment_method: "pm_card_visa"
+    )
+    challenge = Mpp::Challenge.create(
+      secret_key: "test-secret",
+      realm: "test-realm",
+      method: "stripe",
+      intent: "charge",
+      request: {
+        "amount" => "100",
+        "currency" => "usd",
+        "externalId" => "server-order-123",
+        "methodDetails" => {"networkId" => "acct_test123", "paymentMethodTypes" => ["card"]}
+      }
+    )
+
+    credential = method.create_credential(challenge)
+
+    assert_equal "server-order-123", credential.payload["externalId"]
   end
 
   def test_integration_challenge_round_trip

--- a/test/mpp/test_server.rb
+++ b/test/mpp/test_server.rb
@@ -323,6 +323,25 @@ class TestMppHandler < Minitest::Test
     assert_equal 42_431, result.request.dig("methodDetails", "chainId")
   end
 
+  def test_charge_binds_external_id
+    intent = MockIntent.new
+    method = MockMethod.new(
+      intents: {"charge" => intent},
+      currency: "0x20c0000000000000000000000000000000000000",
+      recipient: "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
+    )
+    handler = Mpp::Server::MppHandler.new(
+      method: method,
+      realm: "api.example.com",
+      secret_key: "test-secret"
+    )
+
+    result = handler.charge(nil, "1.00", external_id: "order-123")
+
+    assert_instance_of Mpp::Challenge, result
+    assert_equal "order-123", result.request["externalId"]
+  end
+
   def test_charge_raises_without_intent
     method = MockMethod.new(intents: {})
     handler = Mpp::Server::MppHandler.new(


### PR DESCRIPTION
## Summary

- Source Stripe receipt `externalId` from the HMAC-bound request, not credential payload.
- Add `external_id:` binding on `charge` and Stripe method config.
- Reject missing/mismatched credential echoes and cover forged/payload-only/replay cases.

Towards OSS-324, blocks https://github.com/tempoxyz/mpp-tools/pull/29

## Testing

- `ruby -Ilib -Itest test/mpp/test_server.rb`
- `ruby -Ilib -Itest test/mpp/methods/stripe/test_charge_intent.rb`
- `ruby -Ilib -Itest test/mpp/methods/stripe/test_stripe_method.rb`

-> Local `mpp-tools` (https://github.com/tempoxyz/mpp-tools/pull/29)  Ruby Stripe externalId vector: 5/5 passed.