### PR TITLE
Bump puma to 8.0.2 in examples/tempo_charge

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,11 +152,13 @@ Built on the ["Payment" HTTP Authentication Scheme](https://datatracker.ietf.org
 
 ## Releasing
 
-1. Update the version in `lib/mpp/version.rb`
-2. Run `bundle lock --update mpp-rb` in the root and each `examples/` subdirectory
-3. Commit: `git commit -am "v0.x.x"`
-4. Tag: `git tag v0.x.x`
-5. Push: `git push origin main --tags`
+1. Create a release PR:
+   - Update the version in `lib/mpp/version.rb`
+   - Run `bundle lock --update mpp-rb` in the root and each `examples/` subdirectory
+   - Commit and open a PR to verify CI passes
+2. Merge the PR
+3. Tag the merge commit: `git tag v0.x.x`
+4. Push the tag: `git push origin --tags`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -153,9 +153,10 @@ Built on the ["Payment" HTTP Authentication Scheme](https://datatracker.ietf.org
 ## Releasing
 
 1. Update the version in `lib/mpp/version.rb`
-2. Commit: `git commit -am "v0.x.x"`
-3. Tag: `git tag v0.x.x`
-4. Push: `git push origin main --tags`
+2. Run `bundle lock --update mpp-rb` in the root and each `examples/` subdirectory
+3. Commit: `git commit -am "v0.x.x"`
+4. Tag: `git tag v0.x.x`
+5. Push: `git push origin main --tags`
 
 ## License
 

--- a/examples/stripe_charge/Gemfile.lock
+++ b/examples/stripe_charge/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ../..
   specs:
-    mpp-rb (0.1.1)
-      base64
+    mpp-rb (0.1.3)
+      base64 (~> 0.3)
 
 GEM
   remote: https://rubygems.org/

--- a/examples/tempo_charge/Gemfile.lock
+++ b/examples/tempo_charge/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ../..
   specs:
-    mpp-rb (0.1.1)
-      base64
+    mpp-rb (0.1.3)
+      base64 (~> 0.3)
 
 GEM
   remote: https://rubygems.org/
@@ -12,7 +12,7 @@ GEM
     logger (1.7.0)
     mustermann (3.1.1)
     nio4r (2.7.5)
-    puma (8.0.0)
+    puma (8.0.2)
       nio4r (~> 2.0)
     rack (3.2.6)
     rack-protection (4.2.1)


### PR DESCRIPTION
## Summary
 - Bumps puma from 8.0.0 to 8.0.2 in `examples/tempo_charge`. Fixes security advisory for puma >= 8.0.0, < 8.0.2. Dependabot can't handle this automatically due to a known bug with path gem dependencies in its force_updater
 - Also bump mpp-rb dep of examples, update the "Releasing" instructions in README